### PR TITLE
feat: Add workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ artifacts/
 npm-debug.log
 .DS_STORE
 .*.swp
+.nyc_output

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:6
+
+# Screwdriver Store Version
+ARG VERSION=latest
+
+# Create our application directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Install Screwdriver API
+RUN npm install screwdriver-executor-queue-worker@$VERSION
+WORKDIR /usr/src/app/node_modules/screwdriver-executor-queue-worker
+
+# Setup configuration folder
+RUN ln -s /usr/src/app/node_modules/screwdriver-executor-queue-worker
+/config /config
+
+# Expose the web service port
+EXPOSE 80
+
+# Run the service
+CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,15 @@
 FROM node:6
 
-# Screwdriver Store Version
+# Screwdriver Executor Queue Worker Version
 ARG VERSION=latest
 
 # Create our application directory
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-# Install Screwdriver API
+# Install Screwdriver Executor Queue Worker
 RUN npm install screwdriver-executor-queue-worker@$VERSION
 WORKDIR /usr/src/app/node_modules/screwdriver-executor-queue-worker
-
-# Setup configuration folder
-RUN ln -s /usr/src/app/node_modules/screwdriver-executor-queue-worker
-/config /config
-
-# Expose the web service port
-EXPOSE 80
 
 # Run the service
 CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM node:6
 
-# Screwdriver Executor Queue Worker Version
+# Screwdriver Queue Worker Version
 ARG VERSION=latest
 
 # Create our application directory
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-# Install Screwdriver Executor Queue Worker
-RUN npm install screwdriver-executor-queue-worker@$VERSION
-WORKDIR /usr/src/app/node_modules/screwdriver-executor-queue-worker
+# Install Screwdriver Queue Worker
+RUN npm install screwdriver-queue-worker@$VERSION
+WORKDIR /usr/src/app/node_modules/screwdriver-queue-worker
 
 # Run the service
 CMD [ "npm", "start" ]

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -1,0 +1,46 @@
+# All values in this document are the ENVIRONMENT variable names that can override the defaults
+# from `default.yaml`
+---
+executor:
+    plugin: EXECUTOR_PLUGIN
+    # The NPM module object(s) for the executor plugin(s)
+    k8s:
+      options:
+        kubernetes:
+            # The host or IP of the kubernetes cluster
+            host: K8S_HOST
+            # The jwt token used for authenticating kubernetes requests
+            token: K8S_TOKEN
+            jobsNamespace: K8S_JOBS_NAMESPACE
+        # Launcher container tag to use
+        launchVersion: LAUNCH_VERSION
+        # Prefix to the pod
+        prefix: EXECUTOR_PREFIX
+    k8s-vm:
+      options:
+        # Configuration of Docker
+        kubernetes:
+            # The host or IP of the kubernetes cluster
+            host: K8S_HOST
+            # The jwt token used for authenticating kubernetes requests
+            token: K8S_TOKEN
+            jobsNamespace: K8S_JOBS_NAMESPACE
+            baseImage: K8S_BASE_IMAGE
+        # Launcher container tag to use
+        launchVersion: LAUNCH_VERSION
+        # Prefix to the container
+        prefix: EXECUTOR_PREFIX
+
+ecosystem:
+    # URL for the User Interface
+    api: ECOSYSTEM_API
+    # Externally routable URL for the Artifact Store
+    store: ECOSYSTEM_STORE
+
+redis:
+    # Host of redis cluster
+    host: REDIS_HOST
+    # Password to connect to redis cluster
+    password: REDIS_PASSWORD
+    # Host of redis cluster
+    port: REDIS_PORT

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,0 +1,39 @@
+---
+executor:
+    # Default executor
+    plugin: k8s-vm
+    k8s:
+      options:
+        kubernetes:
+            # The host or IP of the kubernetes cluster
+            host: kubernetes.default
+            # The jwt token used for authenticating kubernetes requests
+            # Loaded from /var/run/secrets/kubernetes.io/serviceaccount/token by default
+
+        # Container tags to use
+        launchVersion: stable
+    k8s-vm:
+      options:
+        # Configuration of Docker
+        kubernetes:
+            # The host or IP of the kubernetes cluster
+            host: kubernetes.default
+            # The jwt token used for authenticating kubernetes requests
+            # Loaded from /var/run/secrets/kubernetes.io/serviceaccount/token by default
+
+        # Launcher container tag to use
+        launchVersion: stable
+
+ecosystem:
+    # Externally routable URL for the User Interface
+    api: https://api.screwdriver.cd
+    # Externally routable URL for the Artifact Store
+    store: https://store.screwdriver.cd
+
+redis:
+    # Host of redis cluster
+    host: 127.0.0.1
+    # Password to connect to redis cluster
+    # password: null
+    # Host of redis cluster
+    port: 6379

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ const jobs = {
  * Update build status to FAILURE
  * @method updateBuildStatus
  * @param  {Object}          updateConfig              build config of the job
- * @param  {string}          updateConfig.failure       failure message
+ * @param  {string}          updateConfig.failure      failure message
  * @param  {Object}          updateConfig.job          job info
  * @param  {Object}          updateConfig.queue        queue of the job
  * @param  {integer}         updateConfig.workerId     id of the workerId

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const NR = require('node-resque');
 const asCallback = require('ascallback');
 const config = require('config');
+const winston = require('winston');
 const ecosystem = config.get('ecosystem');
 const executorConfig = config.get('executor');
 const redisConfig = config.get('redis');
@@ -62,38 +63,36 @@ const multiWorker = new NR.multiWorker({
     toDisconnectProcessors: true
 }, jobs);
 
-/* eslint-disable no-console */
 multiWorker.on('start', workerId =>
-    console.log(`worker[${workerId}] started`));
+    winston.log(`worker[${workerId}] started`));
 multiWorker.on('end', workerId =>
-    console.log(`worker[${workerId}] ended`));
+    winston.log(`worker[${workerId}] ended`));
 multiWorker.on('cleaning_worker', (workerId, worker, pid) =>
-    console.log(`cleaning old worker ${worker} pid ${pid}`));
+    winston.log(`cleaning old worker ${worker} pid ${pid}`));
 multiWorker.on('poll', (workerId, queue) =>
-    console.log(`worker[${workerId}] polling ${queue}`));
+    winston.log(`worker[${workerId}] polling ${queue}`));
 multiWorker.on('job', (workerId, queue, job) =>
-    console.log(`worker[${workerId}] working job ${queue} ${JSON.stringify(job)}}`));
+    winston.log(`worker[${workerId}] working job ${queue} ${JSON.stringify(job)}}`));
 multiWorker.on('reEnqueue', (workerId, queue, job, plugin) =>
-    console.log(`worker[${workerId}] reEnqueue job (${plugin}) ${queue} ${JSON.stringify(job)}`));
+    winston.log(`worker[${workerId}] reEnqueue job (${plugin}) ${queue} ${JSON.stringify(job)}`));
 multiWorker.on('success', (workerId, queue, job, result) =>
-    console.log(`worker[${workerId}] ${job} success ${queue} ${JSON.stringify(job)} >> ${result}`));
-multiWorker.on('failure', (workerId, queue, job, failure) =>
-    console.error(`worker[${workerId}] ${job} failure ${queue}
-        ${JSON.stringify(job)} >> ${failure}`));
+    winston.log(`worker[${workerId}] ${job} success ${queue} ${JSON.stringify(job)} >> ${result}`));
+multiWorker.on('failure', (workerId, queue, job, failure) => winston.error(
+    `worker[${workerId}] ${job} failure ${queue} ${JSON.stringify(job)} >> ${failure}`));
 multiWorker.on('error', (workerId, queue, job, error) =>
-    console.error(`worker[${workerId}] error ${queue} ${JSON.stringify(job)} >> ${error}`));
+    winston.error(`worker[${workerId}] error ${queue} ${JSON.stringify(job)} >> ${error}`));
 multiWorker.on('pause', workerId =>
-    console.log(`worker[${workerId}] paused`));
+    winston.log(`worker[${workerId}] paused`));
 
 // multiWorker emitters
 multiWorker.on('internalError', error =>
-    console.error(error));
+    winston.error(error));
 multiWorker.on('multiWorkerAction', (verb, delay) =>
-    console.log(`*** checked for worker status: ${verb} (event loop delay: ${delay}ms)`));
-/* eslint-disable no-console */
+    winston.log(`*** checked for worker status: ${verb} (event loop delay: ${delay}ms)`));
 
 multiWorker.start();
 
 module.exports = {
-    jobs
+    jobs,
+    multiWorker
 };

--- a/index.js
+++ b/index.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const NR = require('node-resque');
+
+// SET UP THE CONNECTION
+const connectionDetails = {
+    pkg: 'ioredis',
+    host: 'redishost',
+    password: null,
+    port: 1234,
+    database: 0
+};
+
+// DEFINE YOUR WORKER TASKS
+const jobs = {
+    start: {
+        plugins: ['jobLock', 'retry'],
+        pluginOptions: {
+            jobLock: {},
+            retry: {
+                retryLimit: 3,
+                retryDelay: (1000 * 5)
+            }
+        },
+        /* config looks like this
+            executor:
+                name: k8s-vm
+                options:
+                    kubernetes: ...
+            buildConfig:
+                apiUri:
+                buildId:
+                container:
+                token:
+         */
+        perform: (config, callback) => {
+            // eslint-disable-next-line
+            const ExecutorPlugin = require(`screwdriver-executor-${config.executor.name}`);
+            const executor = new ExecutorPlugin(config.executor.options);
+
+            return executor.start(config.buildConfig)
+            .then(() => callback(null))
+            .catch(err => callback(err));
+        }
+    }
+};
+
+// START A WORKER
+// eslint-disable-next-line
+const worker = new NR.multiWorker({
+    connection: connectionDetails,
+    queues: ['builds'] },
+    jobs);
+
+worker.connect(() => {
+    worker.workerCleanup(); // optional: cleanup any previous improperly shutdown workers on this host
+    worker.start();
+});
+
+// REGESTER FOR EVENTS
+worker.on('start', () => console.log(
+    'worker started'));
+worker.on('end', () => console.log(
+    'worker ended'));
+worker.on('cleaning_worker', (w, pid) => console.log(
+    `cleaning old worker ${w} with pid ${pid}`));
+worker.on('poll', queue => console.log(
+    `worker polling ${queue}`));
+worker.on('job', (queue, job) => console.log(
+    `working job ${queue} ${JSON.stringify(job)}`));
+worker.on('reEnqueue', (queue, job, plugin) => console.log(
+    `reEnqueue job (${plugin}) ${queue} ${JSON.stringify(job)}`));
+worker.on('success', (queue, job, result) => console.log(
+    `job success ${queue} ${JSON.stringify(job)} >> ${result}`));
+worker.on('failure', (queue, job, failure) => console.log(
+    `job failure ${queue} ${JSON.stringify(job)} >> ${failure}`));
+worker.on('error', (queue, job, error) => console.log(
+    `error ${queue} ${JSON.stringify(job)} >> ${error}`));
+worker.on('pause', () => console.log(
+    'worker paused'));

--- a/index.js
+++ b/index.js
@@ -1,13 +1,16 @@
 'use strict';
 
-const NR = require('node-resque');
 const asCallback = require('ascallback');
 const config = require('config');
+const NR = require('node-resque');
+const request = require('request');
 const winston = require('winston');
+
 const ecosystem = config.get('ecosystem');
 const executorConfig = config.get('executor');
 const redisConfig = config.get('redis');
-const ExecutorPlugin = require('screwdriver-executor-router');
+
+const ExecutorRouter = require('screwdriver-executor-router');
 const executorPlugins = Object.keys(executorConfig).reduce((aggregator, keyName) => {
     if (keyName !== 'plugin') {
         aggregator.push(Object.assign({
@@ -17,11 +20,12 @@ const executorPlugins = Object.keys(executorConfig).reduce((aggregator, keyName)
 
     return aggregator;
 }, []);
-const executor = new ExecutorPlugin({
+const executor = new ExecutorRouter({
     defaultPlugin: executorConfig.plugin,
     executor: executorPlugins,
     ecosystem
 });
+
 const connectionDetails = {
     pkg: 'ioredis',
     host: redisConfig.REDIS_HOST,
@@ -29,6 +33,7 @@ const connectionDetails = {
     port: redisConfig.REDIS_PORT,
     database: 0
 };
+
 const jobs = {
     start: {
         /**
@@ -42,15 +47,49 @@ const jobs = {
          * @param {String}  buildConfig.token         JWT to act on behalf of the build
          */
         perform: (buildConfig, callback) =>
-            asCallback(executor.start(buildConfig), (err) => {
-                if (err) {
-                    return callback(err);
-                }
-
-                return callback(null);
-            })
+            asCallback(executor.start(buildConfig), callback)
     }
 };
+
+/**
+ * Update build status to FAILURE
+ * @method updateBuildStatus
+ * @param  {Object}          updateConfig              build config of the job
+ * @param  {string}          updateConfig.failure       failure message
+ * @param  {Object}          updateConfig.job          job info
+ * @param  {Object}          updateConfig.queue        queue of the job
+ * @param  {integer}         updateConfig.workerId     id of the workerId
+ * @param  {Function}        [callback]                Callback function
+ * @return {Object}          err                       Callback with err object
+ */
+function updateBuildStatus(updateConfig, callback) {
+    const { failure, job, queue, workerId } = updateConfig;
+    const { apiUri, buildId, token } = updateConfig.job.args[0];
+
+    return request({
+        json: true,
+        method: 'POST',
+        uri: `${apiUri}/v4/builds/${buildId}`,
+        payload: {
+            status: 'FAILURE'
+        },
+        auth: {
+            bearer: token
+        }
+    }, (err, response) => {
+        if (!err && response.statusCode === 200) {
+            // eslint-disable-next-line max-len
+            winston.error(`worker[${workerId}] ${job} failure ${queue} ${JSON.stringify(job)} >> successfully update build status: ${failure}`);
+            callback(null);
+        } else {
+            // eslint-disable-next-line max-len
+            winston.error(`worker[${workerId}] ${job} failure ${queue} ${JSON.stringify(job)} >> ${failure} ${err} ${response}`);
+            callback(err);
+        }
+    });
+}
+
+const supportFunction = { updateBuildStatus };
 
 // eslint-disable-next-line new-cap
 const multiWorker = new NR.multiWorker({
@@ -77,8 +116,8 @@ multiWorker.on('reEnqueue', (workerId, queue, job, plugin) =>
     winston.log(`worker[${workerId}] reEnqueue job (${plugin}) ${queue} ${JSON.stringify(job)}`));
 multiWorker.on('success', (workerId, queue, job, result) =>
     winston.log(`worker[${workerId}] ${job} success ${queue} ${JSON.stringify(job)} >> ${result}`));
-multiWorker.on('failure', (workerId, queue, job, failure) => winston.error(
-    `worker[${workerId}] ${job} failure ${queue} ${JSON.stringify(job)} >> ${failure}`));
+multiWorker.on('failure', (workerId, queue, job, failure) =>
+    supportFunction.updateBuildStatus({ workerId, queue, job, failure }, () => {}));
 multiWorker.on('error', (workerId, queue, job, error) =>
     winston.error(`worker[${workerId}] error ${queue} ${JSON.stringify(job)} >> ${error}`));
 multiWorker.on('pause', workerId =>
@@ -92,7 +131,13 @@ multiWorker.on('multiWorkerAction', (verb, delay) =>
 
 multiWorker.start();
 
+process.on('SIGTERM', () => {
+    multiWorker.end();
+    process.exit();
+});
+
 module.exports = {
     jobs,
-    multiWorker
+    multiWorker,
+    supportFunction
 };

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ascallback": "^1.1.1",
     "config": "^1.26.1",
     "node-resque": "^4.0.7",
+    "request": "^2.81.0",
     "screwdriver-executor-docker": "^2.2.2",
     "screwdriver-executor-k8s": "^10.3.4",
     "screwdriver-executor-k8s-vm": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "screwdriver-executor-docker": "^2.2.2",
     "screwdriver-executor-k8s": "^10.3.4",
     "screwdriver-executor-k8s-vm": "^1.0.1",
-    "screwdriver-executor-router": "^1.0.1"
+    "screwdriver-executor-router": "^1.0.1",
+    "winston": "^2.3.1"
   },
   "release": {
     "debug": false,

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "screwdriver-executor-queue-worker",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Create executor queue worker(s)",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
     "test": "jenkins-mocha --recursive",
+    "start": "node index.js",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -34,13 +35,13 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "devDependencies": {
-    "chai": "^3.5.0",
-    "eslint": "^3.9.1",
-    "eslint-config-screwdriver": "^2.0.9",
-    "jenkins-mocha": "^4.0.0"
+    "eslint": "^4.3.0",
+    "eslint-config-screwdriver": "^3.0.0"
   },
   "dependencies": {
-    "node-resque": "^4.0.7"
+    "node-resque": "^4.0.7",
+    "screwdriver-executor-k8s": "^10.3.4",
+    "screwdriver-executor-k8s-vm": "^1.0.1"
   },
   "release": {
     "debug": false,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "screwdriver-executor-queue-worker",
+  "name": "screwdriver-queue-worker",
   "version": "1.0.0",
-  "description": "Create executor queue worker(s)",
+  "description": "Create queue worker(s)",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
@@ -39,6 +39,7 @@
     "eslint-config-screwdriver": "^3.0.0"
   },
   "dependencies": {
+    "ascallback": "^1.1.1",
     "node-resque": "^4.0.7",
     "screwdriver-executor-k8s": "^10.3.4",
     "screwdriver-executor-k8s-vm": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -35,14 +35,21 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "devDependencies": {
+    "chai": "^4.1.1",
     "eslint": "^4.3.0",
-    "eslint-config-screwdriver": "^3.0.0"
+    "eslint-config-screwdriver": "^3.0.0",
+    "jenkins-mocha": "^5.0.0",
+    "mockery": "^2.1.0",
+    "sinon": "^3.1.0"
   },
   "dependencies": {
     "ascallback": "^1.1.1",
+    "config": "^1.26.1",
     "node-resque": "^4.0.7",
+    "screwdriver-executor-docker": "^2.2.2",
     "screwdriver-executor-k8s": "^10.3.4",
-    "screwdriver-executor-k8s-vm": "^1.0.1"
+    "screwdriver-executor-k8s-vm": "^1.0.1",
+    "screwdriver-executor-router": "^1.0.1"
   },
   "release": {
     "debug": false,

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "eslint-config-screwdriver": "^2.0.9",
     "jenkins-mocha": "^4.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "node-resque": "^4.0.7"
+  },
   "release": {
     "debug": false,
     "verifyConditions": {

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -20,7 +20,7 @@ jobs:
             - docker: ./ci/docker.sh
         environment:
             # Docker hub repo
-            DOCKER_REPO: screwdrivercd/executor-queue-worker
+            DOCKER_REPO: screwdrivercd/queue-worker
         secrets:
             # Publishing to NPM
             - NPM_TOKEN

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,6 @@
 workflow:
     - publish
+    - prod
 
 shared:
     image: node:6
@@ -10,12 +11,38 @@ jobs:
             - install: npm install
             - test: npm test
 
+    # Publish the package to GitHub and build docker image
     publish:
         steps:
+            - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
             - install: npm install semantic-release
             - publish: npm run semantic-release
+            - docker: ./ci/docker.sh
+        environment:
+            # Docker hub repo
+            DOCKER_REPO: screwdrivercd/executor-queue-worker
         secrets:
             # Publishing to NPM
             - NPM_TOKEN
             # Pushing tags to Git
             - GH_TOKEN
+            # Trigger a Docker Hub build
+            - DOCKER_TRIGGER
+
+    # Deploy to our prod environment and run tests
+    prod:
+        steps:
+            - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
+            - get-tag: ./ci/git-latest.sh
+            - wait-docker: DOCKER_TAG=`cat VERSION` ./ci/docker-wait.sh
+            - deploy-k8s: K8S_TAG=`cat VERSION` ./ci/k8s-deploy.sh
+            - test: echo Put acceptance tests here
+        environment:
+            DOCKER_REPO: screwdrivercd/executor-queue-worker
+            K8S_CONTAINER: screwdrivercd/executor-queue-worker
+            K8S_IMAGE: screwdrivercd/executor-queue-worker
+            K8S_HOST: api.k8s.screwdriver.cd
+            K8S_DEPLOYMENT: queue-worker
+        secrets:
+            # Talking to Kubernetes
+            - K8S_TOKEN

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -9,6 +9,7 @@ jobs:
     main:
         steps:
             - install: npm install
+            - test: npm test
 
     # Publish the package to GitHub and build docker image
     publish:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -9,7 +9,6 @@ jobs:
     main:
         steps:
             - install: npm install
-            - test: npm test
 
     # Publish the package to GitHub and build docker image
     publish:

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -1,0 +1,4 @@
+extends: screwdriver
+rules:
+    func-names: off
+    prefer-arrow-callback: off

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -1,4 +1,0 @@
-extends: screwdriver
-rules:
-    func-names: off
-    prefer-arrow-callback: off

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,9 +1,0 @@
-'use strict';
-
-const assert = require('chai').assert;
-
-describe('index test', () => {
-    it('fails', () => {
-        assert.isTrue(false);
-    });
-});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+let jobs;
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('index test', () => {
+    let executorMockClass;
+    let executorMock;
+    let config;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        executorMock = {
+            start: sinon.stub()
+        };
+        executorMockClass = sinon.stub().returns(executorMock);
+
+        mockery.registerMock('screwdriver-executor-router', executorMockClass);
+
+        // eslint-disable-next-line global-require
+        jobs = require('../index.js').jobs;
+
+        config = {
+            buildId: 8609,
+            container: 'node:6',
+            apiUri: 'http://api.com',
+            token: 'asdf',
+            annotations: {
+                'beta.screwdriver.cd/executor': 'k8s'
+            }
+        };
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('callback with null if start successfully', () => {
+        executorMock.start.resolves(null);
+
+        jobs.start.perform(config, (err) => {
+            assert.calledWith(executorMock.start, config);
+            assert.isNull(err);
+        });
+    });
+
+    it('callback with error if executor fails to start', () => {
+        executorMock.start.rejects(new Error('fails to start'));
+
+        jobs.start.perform(config, (err) => {
+            assert.equal(err.message, 'fails to start');
+        });
+    });
+});


### PR DESCRIPTION
The queue-executor should pass in some config like this:
```
            executor:
                name: k8s-vm
                options:
                    kubernetes: ...
            buildConfig:
                apiUri:
                buildId:
                container:
                token:
```

The worker then just takes this config and create a new Executor instance, then calls start to create a pod with the build config. 

Redis information should be available as `REDIS_HOST`, `REDIS_PORT`, and `REDIS_PORT`

Related: https://github.com/screwdriver-cd/screwdriver/issues/431