### PR TITLE
fix: jobs as a dedicated submodule

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,30 +1,12 @@
 'use strict';
 
-const asCallback = require('ascallback');
 const config = require('config');
+const jobs = require('./lib/jobs');
 const NR = require('node-resque');
 const request = require('request');
 const winston = require('winston');
 
-const ecosystem = config.get('ecosystem');
-const executorConfig = config.get('executor');
 const redisConfig = config.get('redis');
-
-const ExecutorRouter = require('screwdriver-executor-router');
-const executorPlugins = Object.keys(executorConfig).reduce((aggregator, keyName) => {
-    if (keyName !== 'plugin') {
-        aggregator.push(Object.assign({
-            name: keyName
-        }, executorConfig[keyName]));
-    }
-
-    return aggregator;
-}, []);
-const executor = new ExecutorRouter({
-    defaultPlugin: executorConfig.plugin,
-    executor: executorPlugins,
-    ecosystem
-});
 
 const connectionDetails = {
     pkg: 'ioredis',
@@ -32,23 +14,6 @@ const connectionDetails = {
     password: redisConfig.password,
     port: redisConfig.port,
     database: 0
-};
-
-const jobs = {
-    start: {
-        /**
-         * Call executor.start with the buildConfig
-         * @method perform
-         * @param {Object}  buildConfig               Configuration
-         * @param {Object}  [buildConfig.annotations] Optional key/value object
-         * @param {String}  buildConfig.apiUri        Screwdriver's API
-         * @param {String}  buildConfig.buildId       Unique ID for a build
-         * @param {String}  buildConfig.container     Container for the build to run in
-         * @param {String}  buildConfig.token         JWT to act on behalf of the build
-         */
-        perform: (buildConfig, callback) =>
-            asCallback(executor.start(buildConfig), callback)
-    }
 };
 
 /**

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const config = require('config');
+const ecosystem = config.get('ecosystem');
+const executorConfig = config.get('executor');
+const executorPlugins = Object.keys(executorConfig).reduce((aggregator, keyName) => {
+    if (keyName !== 'plugin') {
+        aggregator.push(Object.assign({
+            name: keyName
+        }, executorConfig[keyName]));
+    }
+
+    return aggregator;
+}, []);
+
+const ExecutorRouter = require('screwdriver-executor-router');
+const executor = new ExecutorRouter({
+    defaultPlugin: executorConfig.plugin,
+    executor: executorPlugins,
+    ecosystem
+});
+
+/**
+ * Call executor.start with the buildConfig
+ * @method perform
+ * @param {Object}  buildConfig               Configuration object
+ * @param {Object}  [buildConfig.annotations] Optional key-value object
+ * @param {String}  buildConfig.apiUri        URI for Screwdriver API
+ * @param {String}  buildConfig.buildId       Unique ID for a build
+ * @param {String}  buildConfig.container     Container for the build to run int
+ * @param {String}  buildConfig.token         JWT to act on behalf of the build
+ */
+function start(buildConfig, callback) {
+    return executor.start(buildConfig)
+        .then(result => callback(null, result), err => callback(err));
+}
+
+module.exports = {
+    start
+};

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "sinon": "^3.1.0"
   },
   "dependencies": {
-    "ascallback": "^1.1.1",
     "config": "^1.26.1",
     "node-resque": "^4.0.7",
     "request": "^2.81.0",

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('Jobs Unit Test', () => {
+    let mockExecutor;
+    let mockExecutorRouter;
+    let jobs;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        mockExecutor = {
+            start: sinon.stub()
+        };
+
+        mockExecutorRouter = function () { return mockExecutor; };
+
+        mockery.registerMock('screwdriver-executor-router', mockExecutorRouter);
+
+        // eslint-disable-next-line global-require
+        jobs = require('../lib/jobs');
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    describe('start', () => {
+        it('starts a job', (done) => {
+            const expectedConfig = { buildConfig: 'buildConfig' };
+
+            mockExecutor.start.resolves(null);
+
+            jobs.start(expectedConfig, (err, result) => {
+                assert.isNull(err);
+                assert.isNull(result);
+
+                assert.calledWith(mockExecutor.start, expectedConfig);
+
+                done();
+            });
+        });
+
+        it('returns an error from executor', (done) => {
+            const expectedError = new Error('executor.start Error');
+
+            mockExecutor.start.rejects(expectedError);
+
+            jobs.start({}, (err) => {
+                assert.deepEqual(err, expectedError);
+
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Context

We want to implement a `stop` functionality in the workers. Performing a refactor would make that effort much easier to achieve and isolate the changes away from parts of the module that should not be affected by it.

## Objective

Refactor the `jobs` related functionality into a submodule. 

In addition, raises code coverage:

```
# old
=============================== Coverage summary ===============================
Statements   : 96.43% ( 54/56 )
Branches     : 100% ( 6/6 )
Functions    : 88.89% ( 16/18 )
Lines        : 96.43% ( 54/56 )
================================================================================
```

```
# new
=============================== Coverage summary ===============================
Statements   : 96.61% ( 57/59 )
Branches     : 100% ( 6/6 )
Functions    : 90% ( 18/20 )
Lines        : 96.55% ( 56/58 )
================================================================================
```

## References
