### PR TITLE
feat(693): stop jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,48 @@
 
 > Create executor queue worker(s)
 
+A Resque Worker implementation that consumes jobs and other workloads in a Resque queue.
+
 ## Usage
 
 ```bash
 npm install screwdriver-executor-queue-worker
 ```
+
+### Methods
+
+#### Start
+##### Required Parameters
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config             | Object | Configuration Object |
+| config.annotations | Object | Optional key-value object |
+| config.apiUri      | String | Screwdriver's API |
+| config.buildId     | String | The unique ID for a build |
+| config.container   | String | Container for the build to run in |
+| config.token       | String | JWT to act on behalf of the build |
+
+##### Expected Outcome
+The start function is expected to create a task in the designated execution engine.
+
+##### Expected Return
+A callback of `fn(err, result)`, where `err` is an Error that was encountered (if any) and `result`
+is the data that the execution engine returns.
+
+#### Stop
+##### Required Parameters
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config             | Object | Configuration Object |
+| config.annotations | Object | Optional key-value object |
+| config.buildId     | String | The unique ID for a build |
+
+##### Expected Outcome
+The stop function is expected to stop/cleanup a task in the desginated execution engine.
+
+##### Expected Return
+A callback of `fn(err, result)`, where `err` is an Error that was encountered (if any) and `result`
+is the data that the execution engine returns.
 
 ## Testing
 
@@ -19,13 +56,15 @@ npm test
 
 Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
 
+[executor-base-class]: https://github.com/screwdriver-cd/executor-base
 [npm-image]: https://img.shields.io/npm/v/screwdriver-executor-queue-worker.svg
 [npm-url]: https://npmjs.org/package/screwdriver-executor-queue-worker
 [downloads-image]: https://img.shields.io/npm/dt/screwdriver-executor-queue-worker.svg
 [license-image]: https://img.shields.io/npm/l/screwdriver-executor-queue-worker.svg
 [issues-image]: https://img.shields.io/github/issues/screwdriver-cd/executor-queue-worker.svg
 [issues-url]: https://github.com/screwdriver-cd/executor-queue-worker/issues
-[status-image]: https://cd.screwdriver.cd/pipelines/pipelineid/badge
-[status-url]: https://cd.screwdriver.cd/pipelines/pipelineid
+[status-image]: https://cd.screwdriver.cd/pipelines/301/badge
+[status-url]: https://cd.screwdriver.cd/pipelines/301
+[task]: https://github.com/screwdriver-cd/data-schema/blob/master/model/task.js
 [daviddm-image]: https://david-dm.org/screwdriver-cd/executor-queue-worker.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/screwdriver-cd/executor-queue-worker

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const config = require('config');
+
 const ecosystem = config.get('ecosystem');
 const executorConfig = config.get('executor');
 const executorPlugins = Object.keys(executorConfig).reduce((aggregator, keyName) => {
@@ -22,19 +23,33 @@ const executor = new ExecutorRouter({
 
 /**
  * Call executor.start with the buildConfig
- * @method perform
- * @param {Object}  buildConfig               Configuration object
- * @param {Object}  [buildConfig.annotations] Optional key-value object
- * @param {String}  buildConfig.apiUri        URI for Screwdriver API
- * @param {String}  buildConfig.buildId       Unique ID for a build
- * @param {String}  buildConfig.container     Container for the build to run int
- * @param {String}  buildConfig.token         JWT to act on behalf of the build
+ * @method start
+ * @param {Object}    buildConfig               Configuration object
+ * @param {Object}    [buildConfig.annotations] Optional key-value object
+ * @param {String}    buildConfig.apiUri        URI for Screwdriver API
+ * @param {String}    buildConfig.buildId       Unique ID for a build
+ * @param {String}    buildConfig.container     Container for the build to run int
+ * @param {String}    buildConfig.token         JWT to act on behalf of the build
+ * @param {Function}  callback                  Callback fn(error, result)
  */
 function start(buildConfig, callback) {
     return executor.start(buildConfig)
         .then(result => callback(null, result), err => callback(err));
 }
 
+/**
+ * Call executor.stop with the buildConfig
+ * @method stop
+ * @param {Object}     buildConfig          Configuration object
+ * @param {String}     buildConfig.buildId  Unique ID for a build
+ * @param {Function }  callback             Callback fn(error, result)
+ */
+function stop(buildConfig, callback) {
+    return executor.stop(buildConfig)
+        .then(result => callback(null, result), err => callback(err));
+}
+
 module.exports = {
-    start
+    start,
+    stop
 };

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -40,9 +40,10 @@ function start(buildConfig, callback) {
 /**
  * Call executor.stop with the buildConfig
  * @method stop
- * @param {Object}     buildConfig          Configuration object
- * @param {String}     buildConfig.buildId  Unique ID for a build
- * @param {Function }  callback             Callback fn(error, result)
+ * @param {Object}     buildConfig                Configuration object
+ * @param {Object}     [buildConfig.annotations]  Optional key-value object
+ * @param {String}     buildConfig.buildId        Unique ID for a build
+ * @param {Function}   callback                   Callback fn(error, result)
  */
 function stop(buildConfig, callback) {
     return executor.stop(buildConfig)

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -20,7 +20,8 @@ describe('Jobs Unit Test', () => {
 
     beforeEach(() => {
         mockExecutor = {
-            start: sinon.stub()
+            start: sinon.stub(),
+            stop: sinon.stub()
         };
 
         mockExecutorRouter = function () { return mockExecutor; };
@@ -62,6 +63,35 @@ describe('Jobs Unit Test', () => {
             mockExecutor.start.rejects(expectedError);
 
             jobs.start({}, (err) => {
+                assert.deepEqual(err, expectedError);
+
+                done();
+            });
+        });
+    });
+
+    describe('stop', () => {
+        it('stops a job', (done) => {
+            const expectedConfig = { buildConfig: 'buildConfig' };
+
+            mockExecutor.stop.resolves(null);
+
+            jobs.stop(expectedConfig, (err, result) => {
+                assert.isNull(err);
+                assert.isNull(result);
+
+                assert.calledWith(mockExecutor.stop, expectedConfig);
+
+                done();
+            });
+        });
+
+        it('returns an error from stopping executor', (done) => {
+            const expectedError = new Error('executor.stop Error');
+
+            mockExecutor.stop.rejects(expectedError);
+
+            jobs.stop({}, (err) => {
                 assert.deepEqual(err, expectedError);
 
                 done();


### PR DESCRIPTION
## Context

Currently, the queue workers do not support the ability to stop a build that is already running. 

## Objective

Define a `stop` job that will invoke a stop command with the related execution engine.

## References

* Issue screwdriver-cd/screwdriver#693