### PR TITLE
feat: add prefix to the queue name

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -44,3 +44,5 @@ redis:
     password: REDIS_PASSWORD
     # Host of redis cluster
     port: REDIS_PORT
+    # Prefix for the queue name
+    prefix: EXECUTOR_PREFIX

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -37,3 +37,6 @@ redis:
     # password: null
     # Host of redis cluster
     port: 6379
+    # Prefix for the queue name
+    # prefix: 'beta-'
+

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const connectionDetails = {
     port: redisConfig.port,
     database: 0
 };
+const queuePrefix = redisConfig.prefix || '';
 
 /**
  * Update build status to FAILURE
@@ -59,7 +60,7 @@ const supportFunction = { updateBuildStatus };
 /* eslint-disable new-cap, max-len */
 const multiWorker = new NR.multiWorker({
     connection: connectionDetails,
-    queues: ['builds'],
+    queues: [`${queuePrefix}builds`],
     minTaskProcessors: 1,
     maxTaskProcessors: 10,
     checkTimeout: 1000,


### PR DESCRIPTION
Need to add prefix to the queue name for beta and prod environments.

We will have separate workers for beta and prod. Need different queue names so that they will listen to the right queue.

E.g. for beta-worker, it will listen to 'beta-builds'

