### PR TITLE
fix: fix the format for redis password

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,9 @@ const redisConfig = config.get('redis');
 const connectionDetails = {
     pkg: 'ioredis',
     host: redisConfig.host,
-    password: redisConfig.password,
+    options: {
+        password: redisConfig.password
+    },
     port: redisConfig.port,
     database: 0
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,7 +8,7 @@ const util = require('util');
 
 sinon.assert.expose(assert, { prefix: '' });
 
-describe('index test', () => {
+describe('Index Test', () => {
     const worker = 'abc';
     const pid = '111';
     const plugin = {};
@@ -198,7 +198,9 @@ describe('index test', () => {
                     host: '127.0.0.1',
                     port: 6379,
                     database: 0,
-                    password: undefined
+                    options: {
+                        password: undefined
+                    }
                 }),
                 queues: ['builds'],
                 minTaskProcessors: 1,


### PR DESCRIPTION
This is the right format to consume redis password. 

[node-resque](https://github.com/taskrabbit/node-resque)'s example is lying. 