### PR TITLE
Workers now obtain the build config from redis

### DIFF
--- a/config/redis.js
+++ b/config/redis.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const config = require('config');
+
+const redisConfig = config.get('redis');
+const connectionDetails = {
+    pkg: 'ioredis',
+    host: redisConfig.host,
+    options: {
+        password: redisConfig.password
+    },
+    port: redisConfig.port,
+    database: 0
+};
+const queuePrefix = redisConfig.prefix || '';
+
+module.exports = {
+    connectionDetails,
+    queuePrefix
+};

--- a/index.js
+++ b/index.js
@@ -1,23 +1,10 @@
 'use strict';
 
-const config = require('config');
-const jobs = require('./lib/jobs');
 const NR = require('node-resque');
+const jobs = require('./lib/jobs');
 const request = require('request');
 const winston = require('winston');
-
-const redisConfig = config.get('redis');
-
-const connectionDetails = {
-    pkg: 'ioredis',
-    host: redisConfig.host,
-    options: {
-        password: redisConfig.password
-    },
-    port: redisConfig.port,
-    database: 0
-};
-const queuePrefix = redisConfig.prefix || '';
+const { connectionDetails, queuePrefix } = require('./config/redis');
 
 /**
  * Update build status to FAILURE

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -1,6 +1,10 @@
 'use strict';
 
+const Redis = require('ioredis');
 const config = require('config');
+const { connectionDetails, queuePrefix } = require('../config/redis');
+
+const redis = new Redis(connectionDetails);
 
 const ecosystem = config.get('ecosystem');
 const executorConfig = config.get('executor');
@@ -22,18 +26,16 @@ const executor = new ExecutorRouter({
 });
 
 /**
- * Call executor.start with the buildConfig
+ * Call executor.start with the buildConfig obtained from the redis database
  * @method start
  * @param {Object}    buildConfig               Configuration object
- * @param {Object}    [buildConfig.annotations] Optional key-value object
- * @param {String}    buildConfig.apiUri        URI for Screwdriver API
  * @param {String}    buildConfig.buildId       Unique ID for a build
- * @param {String}    buildConfig.container     Container for the build to run int
- * @param {String}    buildConfig.token         JWT to act on behalf of the build
  * @param {Function}  callback                  Callback fn(error, result)
  */
 function start(buildConfig, callback) {
-    return executor.start(buildConfig)
+    return redis.hget(`${queuePrefix}buildConfigs`, buildConfig.buildId)
+        .then(fullBuildConfig => redis.hdel(`${queuePrefix}buildConfigs`, buildConfig.buildId)
+            .then(() => executor.start(fullBuildConfig)))
         .then(result => callback(null, result), err => callback(err));
 }
 
@@ -41,7 +43,6 @@ function start(buildConfig, callback) {
  * Call executor.stop with the buildConfig
  * @method stop
  * @param {Object}     buildConfig                Configuration object
- * @param {Object}     [buildConfig.annotations]  Optional key-value object
  * @param {String}     buildConfig.buildId        Unique ID for a build
  * @param {Function}   callback                   Callback fn(error, result)
  */

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -47,7 +47,8 @@ function start(buildConfig, callback) {
  * @param {Function}   callback                   Callback fn(error, result)
  */
 function stop(buildConfig, callback) {
-    return executor.stop(buildConfig)
+    return redis.hdel(`${queuePrefix}buildConfigs`, buildConfig.buildId)
+        .then(() => executor.stop(buildConfig))
         .then(result => callback(null, result), err => callback(err));
 }
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "config": "^1.26.1",
+    "ioredis": "^3.1.4",
     "node-resque": "^4.0.7",
     "request": "^2.81.0",
     "screwdriver-executor-docker": "^2.2.2",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -35,6 +35,7 @@ describe('Index Test', () => {
     let spyMultiWorker;
     let winstonMock;
     let requestMock;
+    let redisConfigMock;
     let index;
     let testWorker;
     let supportFunction;
@@ -69,11 +70,16 @@ describe('Index Test', () => {
         updateBuildStatusMock = sinon.stub();
         processExitMock = sinon.stub();
         process.exit = processExitMock;
+        redisConfigMock = {
+            connectionDetails: 'mockRedisConfig',
+            queuePrefix: 'mockQueuePrefix_'
+        };
 
         mockery.registerMock('./lib/jobs', mockJobs);
         mockery.registerMock('node-resque', nrMockClass);
         mockery.registerMock('winston', winstonMock);
         mockery.registerMock('request', requestMock);
+        mockery.registerMock('./config/redis', redisConfigMock);
 
         // eslint-disable-next-line global-require
         index = require('../index.js');
@@ -193,16 +199,8 @@ describe('Index Test', () => {
     describe('multiWorker', () => {
         it('is constructed correctly', () => {
             const expectedConfig = {
-                connection: sinon.match({
-                    pkg: 'ioredis',
-                    host: '127.0.0.1',
-                    port: 6379,
-                    database: 0,
-                    options: {
-                        password: undefined
-                    }
-                }),
-                queues: ['builds'],
+                connection: 'mockRedisConfig',
+                queues: ['mockQueuePrefix_builds'],
                 minTaskProcessors: 1,
                 maxTaskProcessors: 10,
                 checkTimeout: 1000,

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -7,9 +7,11 @@ const sinon = require('sinon');
 sinon.assert.expose(assert, { prefix: '' });
 
 describe('Jobs Unit Test', () => {
+    let jobs;
     let mockExecutor;
     let mockExecutorRouter;
-    let jobs;
+    let mockRedis;
+    let mockRedisObj;
 
     before(() => {
         mockery.enable({
@@ -24,9 +26,16 @@ describe('Jobs Unit Test', () => {
             stop: sinon.stub()
         };
 
-        mockExecutorRouter = function () { return mockExecutor; };
+        mockRedisObj = {
+            hget: sinon.stub(),
+            hdel: sinon.stub()
+        };
 
+        mockExecutorRouter = function () { return mockExecutor; };
         mockery.registerMock('screwdriver-executor-router', mockExecutorRouter);
+
+        mockRedis = sinon.stub().returns(mockRedisObj);
+        mockery.registerMock('ioredis', mockRedis);
 
         // eslint-disable-next-line global-require
         jobs = require('../lib/jobs');
@@ -41,26 +50,83 @@ describe('Jobs Unit Test', () => {
         mockery.disable();
     });
 
+    describe('redis constructor', () => {
+        it('creates a redis connection given a valid config', () => {
+            const redisConfig = {
+                database: 0,
+                pkg: 'ioredis',
+                host: '127.0.0.1',
+                options: {
+                    password: undefined
+                },
+                port: 6379
+            };
+
+            assert.calledWith(mockRedis, redisConfig);
+        });
+    });
+
     describe('start', () => {
         it('starts a job', (done) => {
-            const expectedConfig = { buildConfig: 'buildConfig' };
+            const expectedConfig = {
+                annotations: {
+                    'beta.screwdriver.cd/executor': 'screwdriver-executor-k8s'
+                },
+                buildId: 8609,
+                container: 'node:4',
+                apiUri: 'http://api.com',
+                token: 'asdf'
+            };
 
             mockExecutor.start.resolves(null);
+            mockRedisObj.hget.resolves(expectedConfig);
+            mockRedisObj.hdel.resolves(1);
 
-            jobs.start(expectedConfig, (err, result) => {
+            jobs.start({ buildId: expectedConfig.buildId }, (err, result) => {
                 assert.isNull(err);
                 assert.isNull(result);
 
                 assert.calledWith(mockExecutor.start, expectedConfig);
+
+                assert.calledWith(mockRedisObj.hget, 'buildConfigs', expectedConfig.buildId);
+                assert.calledWith(mockRedisObj.hdel, 'buildConfigs', expectedConfig.buildId);
 
                 done();
             });
         });
 
         it('returns an error from executor', (done) => {
+            mockRedisObj.hget.resolves({});
+            mockRedisObj.hdel.resolves(1);
+
             const expectedError = new Error('executor.start Error');
 
             mockExecutor.start.rejects(expectedError);
+
+            jobs.start({}, (err) => {
+                assert.deepEqual(err, expectedError);
+
+                done();
+            });
+        });
+
+        it('returns an error when redis fails to get a config', (done) => {
+            const expectedError = new Error('hget error');
+
+            mockRedisObj.hget.rejects(expectedError);
+
+            jobs.start({}, (err) => {
+                assert.deepEqual(err, expectedError);
+
+                done();
+            });
+        });
+
+        it('returns an error when redis fails to remove a config', (done) => {
+            const expectedError = new Error('hdel error');
+
+            mockRedisObj.hget.resolves({});
+            mockRedisObj.hdel.rejects(expectedError);
 
             jobs.start({}, (err) => {
                 assert.deepEqual(err, expectedError);

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -70,7 +70,7 @@ describe('Jobs Unit Test', () => {
         it('starts a job', (done) => {
             const expectedConfig = {
                 annotations: {
-                    'beta.screwdriver.cd/executor': 'screwdriver-executor-k8s'
+                    'beta.screwdriver.cd/executor': 'k8s'
                 },
                 buildId: 8609,
                 container: 'node:4',

--- a/test/redis.test.js
+++ b/test/redis.test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('redis config test', () => {
+    let configMock;
+    let redisConfig;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        configMock = {
+            get: sinon.stub().returns({
+                host: 'mockhost',
+                port: '1234',
+                password: 'SUPER_SECURE_PASSWORD',
+                prefix: 'mockPrefix_'
+            })
+        };
+
+        mockery.registerMock('config', configMock);
+
+        // eslint-disable-next-line global-require
+        redisConfig = require('../config/redis');
+    });
+
+    it('populates the correct values', () => {
+        assert.deepEqual(redisConfig, {
+            connectionDetails: {
+                pkg: 'ioredis',
+                host: 'mockhost',
+                options: {
+                    password: 'SUPER_SECURE_PASSWORD'
+                },
+                port: '1234',
+                database: 0
+            },
+            queuePrefix: 'mockPrefix_'
+        });
+    });
+
+    it('defaults prefix to empty', () => {
+        configMock.get.returns({
+            mockPrefix: undefined
+        });
+
+        mockery.resetCache();
+
+        // eslint-disable-next-line global-require
+        redisConfig = require('../config/redis');
+
+        assert.strictEqual(redisConfig.queuePrefix, '');
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+});


### PR DESCRIPTION
The executor-queue plugin puts the full build configuration into a redis database. This PR ensures that the workers will get that config from redis as the first step when processing jobs.

Merge with https://github.com/screwdriver-cd/executor-queue/pull/7