### PR TITLE
fix(redis): fix format of ioredis constructor

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -4,7 +4,7 @@ const Redis = require('ioredis');
 const config = require('config');
 const { connectionDetails, queuePrefix } = require('../config/redis');
 
-const redis = new Redis(connectionDetails);
+const redis = new Redis(connectionDetails.port, connectionDetails.host, connectionDetails.options);
 
 const ecosystem = config.get('ecosystem');
 const executorConfig = config.get('executor');

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -52,17 +52,13 @@ describe('Jobs Unit Test', () => {
 
     describe('redis constructor', () => {
         it('creates a redis connection given a valid config', () => {
-            const redisConfig = {
-                database: 0,
-                pkg: 'ioredis',
-                host: '127.0.0.1',
-                options: {
-                    password: undefined
-                },
-                port: 6379
+            const expectedPort = 6379;
+            const expectedHost = '127.0.0.1';
+            const expectedOptions = {
+                password: undefined
             };
 
-            assert.calledWith(mockRedis, redisConfig);
+            assert.calledWith(mockRedis, expectedPort, expectedHost, expectedOptions);
         });
     });
 


### PR DESCRIPTION
`ioredis` takes its options in a slightly different way than `node-resque`.

This pull calls the constructor in the same way as `node-resque`.

## References
https://github.com/luin/ioredis/blob/master/lib/redis.js#L100
https://github.com/luin/ioredis/blob/master/API.md#new_Redis