### PR TITLE
fix(redis): parse the buildconfig objects

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -34,6 +34,7 @@ const executor = new ExecutorRouter({
  */
 function start(buildConfig, callback) {
     return redis.hget(`${queuePrefix}buildConfigs`, buildConfig.buildId)
+        .then(JSON.parse)
         .then(fullBuildConfig => redis.hdel(`${queuePrefix}buildConfigs`, buildConfig.buildId)
             .then(() => executor.start(fullBuildConfig)))
         .then(result => callback(null, result), err => callback(err));


### PR DESCRIPTION
* Buildconfigs are being stored in redis as strings, need to `JSON.parse` them before using
* Switch tests to use promises instead of `done` callbacks