### PR TITLE
feat: adding retry for job start and stop

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -24,6 +24,17 @@ const executor = new ExecutorRouter({
     executor: executorPlugins,
     ecosystem
 });
+const RETRY_LIMIT = 3;
+const RETRY_DELAY = 1000;
+const retryOptions = {
+    plugins: ['Retry'],
+    pluginOptions: {
+        Retry: {
+            retryLimit: RETRY_LIMIT,
+            retryDelay: RETRY_DELAY
+        }
+    }
+};
 
 /**
  * Call executor.start with the buildConfig obtained from the redis database
@@ -54,6 +65,6 @@ function stop(buildConfig, callback) {
 }
 
 module.exports = {
-    start,
-    stop
+    start: Object.assign({ perform: start }, retryOptions),
+    stop: Object.assign({ perform: stop }, retryOptions)
 };

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -63,6 +63,19 @@ describe('Jobs Unit Test', () => {
     });
 
     describe('start', () => {
+        it('constructs start job correctly', () =>
+            assert.deepEqual(jobs.start, {
+                plugins: ['Retry'],
+                pluginOptions: {
+                    Retry: {
+                        retryLimit: 3,
+                        retryDelay: 1000
+                    }
+                },
+                perform: jobs.start.perform
+            })
+        );
+
         it('starts a job', () => {
             const expectedConfig = JSON.stringify({
                 annotations: {
@@ -78,7 +91,7 @@ describe('Jobs Unit Test', () => {
             mockRedisObj.hget.resolves(expectedConfig);
             mockRedisObj.hdel.resolves(1);
 
-            return jobs.start({ buildId: expectedConfig.buildId }, (err, result) => {
+            return jobs.start.perform({ buildId: expectedConfig.buildId }, (err, result) => {
                 assert.isNull(err);
                 assert.isNull(result);
 
@@ -97,7 +110,7 @@ describe('Jobs Unit Test', () => {
 
             mockExecutor.start.rejects(expectedError);
 
-            return jobs.start({}, (err) => {
+            return jobs.start.perform({}, (err) => {
                 assert.deepEqual(err, expectedError);
             });
         });
@@ -107,7 +120,7 @@ describe('Jobs Unit Test', () => {
 
             mockRedisObj.hget.rejects(expectedError);
 
-            return jobs.start({}, (err) => {
+            return jobs.start.perform({}, (err) => {
                 assert.deepEqual(err, expectedError);
             });
         });
@@ -118,20 +131,33 @@ describe('Jobs Unit Test', () => {
             mockRedisObj.hget.resolves('{}');
             mockRedisObj.hdel.rejects(expectedError);
 
-            return jobs.start({}, (err) => {
+            return jobs.start.perform({}, (err) => {
                 assert.deepEqual(err, expectedError);
             });
         });
     });
 
     describe('stop', () => {
+        it('constructs stop job correctly', () =>
+            assert.deepEqual(jobs.stop, {
+                plugins: ['Retry'],
+                pluginOptions: {
+                    Retry: {
+                        retryLimit: 3,
+                        retryDelay: 1000
+                    }
+                },
+                perform: jobs.stop.perform
+            })
+        );
+
         it('stops a job', () => {
             const expectedConfig = { buildConfig: 'buildConfig' };
 
             mockExecutor.stop.resolves(null);
             mockRedisObj.hdel.resolves(1);
 
-            return jobs.stop(expectedConfig, (err, result) => {
+            return jobs.stop.perform(expectedConfig, (err, result) => {
                 assert.isNull(err);
                 assert.isNull(result);
 
@@ -146,7 +172,7 @@ describe('Jobs Unit Test', () => {
             mockRedisObj.hdel.resolves(1);
             mockExecutor.stop.rejects(expectedError);
 
-            return jobs.stop({}, (err) => {
+            return jobs.stop.perform({}, (err) => {
                 assert.deepEqual(err, expectedError);
             });
         });
@@ -156,7 +182,7 @@ describe('Jobs Unit Test', () => {
 
             mockRedisObj.hdel.rejects(expectedError);
 
-            return jobs.stop({}, (err) => {
+            return jobs.stop.perform({}, (err) => {
                 assert.deepEqual(err, expectedError);
             });
         });


### PR DESCRIPTION
 adding retry for job start and stop

Reference: https://github.com/taskrabbit/node-resque/blob/master/examples/retry.js
Blocked by: https://github.com/screwdriver-cd/executor-k8s-vm/pull/7