### PR TITLE
fix: plugin name should be lower case

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -27,9 +27,9 @@ const executor = new ExecutorRouter({
 const RETRY_LIMIT = 3;
 const RETRY_DELAY = 1000;
 const retryOptions = {
-    plugins: ['Retry'],
+    plugins: ['retry'],
     pluginOptions: {
-        Retry: {
+        retry: {
             retryLimit: RETRY_LIMIT,
             retryDelay: RETRY_DELAY
         }

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -65,9 +65,9 @@ describe('Jobs Unit Test', () => {
     describe('start', () => {
         it('constructs start job correctly', () =>
             assert.deepEqual(jobs.start, {
-                plugins: ['Retry'],
+                plugins: ['retry'],
                 pluginOptions: {
-                    Retry: {
+                    retry: {
                         retryLimit: 3,
                         retryDelay: 1000
                     }
@@ -140,9 +140,9 @@ describe('Jobs Unit Test', () => {
     describe('stop', () => {
         it('constructs stop job correctly', () =>
             assert.deepEqual(jobs.stop, {
-                plugins: ['Retry'],
+                plugins: ['retry'],
                 pluginOptions: {
-                    Retry: {
+                    retry: {
                         retryLimit: 3,
                         retryDelay: 1000
                     }


### PR DESCRIPTION
plugin name should be lower case

They change the plugin name to uppercase in latest release.
We are using an older version which user lowercase.

https://www.npmjs.com/package/node-resque