### PR TITLE
fix: reduce the retryLimit to 5

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -25,7 +25,7 @@ const executor = new ExecutorRouter({
     ecosystem
 });
 const RETRY_LIMIT = 3;
-const RETRY_DELAY = 10;
+const RETRY_DELAY = 5;
 const retryOptions = {
     plugins: ['retry'],
     pluginOptions: {

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -25,7 +25,7 @@ const executor = new ExecutorRouter({
     ecosystem
 });
 const RETRY_LIMIT = 3;
-const RETRY_DELAY = 1000;
+const RETRY_DELAY = 10;
 const retryOptions = {
     plugins: ['retry'],
     pluginOptions: {

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -69,7 +69,7 @@ describe('Jobs Unit Test', () => {
                 pluginOptions: {
                     retry: {
                         retryLimit: 3,
-                        retryDelay: 1000
+                        retryDelay: 5
                     }
                 },
                 perform: jobs.start.perform
@@ -144,7 +144,7 @@ describe('Jobs Unit Test', () => {
                 pluginOptions: {
                     retry: {
                         retryLimit: 3,
-                        retryDelay: 1000
+                        retryDelay: 5
                     }
                 },
                 perform: jobs.stop.perform


### PR DESCRIPTION
The retryLimit is in seconds instead of miliseconds.
Their documentation didn't mentioned anything about it.