### PR TITLE
feat(432): add jenkins-executor settings to config

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -30,6 +30,35 @@ executor:
         launchVersion: LAUNCH_VERSION
         # Prefix to the container
         prefix: EXECUTOR_PREFIX
+    jenkins:
+      options:
+        jenkins:
+            host: EXECUTOR_JENKINS_HOST
+            port: EXECUTOR_JENKINS_PORT
+            username: EXECUTOR_JENKINS_USERNAME
+            # Jenkins password/token used for authenticating jenkins requests
+            password: EXECUTOR_JENKINS_PASSWORD
+            # Node labels of Jenkins slaves
+            nodeLabel: EXECUTOR_JENKINS_NODE_LABEL
+        docker:
+            # The path to the docker-compose command
+            composeCommand: EXECUTOR_JENKINS_DOCKER_COMPOSE_COMMAND
+            # Prefix to the container
+            prefix: EXECUTOR_JENKINS_DOCKER_PREFIX
+            # Launcher container tag to use
+            launchVersion: EXECUTOR_JENKINS_LAUNCH_VERSION
+            # Memory limit (docker run `--memory` option)
+            memory: EXECUTOR_JENKINS_DOCKER_MEMORY
+            # Memory limit include swap (docker run `--memory-swap` option)
+            memoryLimit: EXECUTOR_JENKINS_DOCKER_MEMORY_LIMIT
+        # The command to start build
+        buildScript: EXECUTOR_JENKINS_BUILD_SCRIPT
+        # The command to clean up build system
+        cleanupScript: EXECUTOR_JENKINS_CLEANUP_SCRIPT
+        # Time (seconds) to destroy the job
+        cleanupTimeLimit: EXECUTOR_JENKINS_CLEANUP_TIME_LIMIT
+        # Interval to detect the stopped job (seconds)
+        cleanupWatchInterval: EXECUTOR_JENKINS_CLEANUP_WATCH_INTERVAL
 
 ecosystem:
     # URL for the User Interface

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -23,6 +23,14 @@ executor:
 
         # Launcher container tag to use
         launchVersion: stable
+#     jenkins:
+#       options:
+#         # Configuration of Jenkins
+#         jenkins:
+#             host: jenkins.default
+#             port: 8080
+#             username: screwdriver
+#             password: "WOW-AN-EVEN-MORE-INSECURE-PASSWORD!!!!"
 
 ecosystem:
     # Externally routable URL for the User Interface

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "node-resque": "^4.0.7",
     "request": "^2.81.0",
     "screwdriver-executor-docker": "^2.2.2",
+    "screwdriver-executor-jenkins": "^2.0.0",
     "screwdriver-executor-k8s": "^10.3.4",
     "screwdriver-executor-k8s-vm": "^1.1.3",
     "screwdriver-executor-router": "^1.0.1",


### PR DESCRIPTION
## Context
We'd like to use jenkins executor via `queue-worker`, but `queue-worker` has no settings for that.

## Objective
This PR adds the settings for the jenkins executor.
The original settings are [default.yaml](https://github.com/screwdriver-cd/screwdriver/blob/master/config/default.yaml#L124-L131) and [custom-environment-varialbes.yaml](https://github.com/screwdriver-cd/screwdriver/blob/master/config/custom-environment-variables.yaml#L102-L131).
And I adjust the settings like other executor settings (remove `enabled` setting from custom-environment-variables.yaml).

## References

https://github.com/screwdriver-cd/screwdriver/issues/432