### PR TITLE
feat: configuration flag for enabling Redis TLS communication

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -71,7 +71,9 @@ redis:
     host: REDIS_HOST
     # Password to connect to redis cluster
     password: REDIS_PASSWORD
-    # Host of redis cluster
+    # Port of redis cluster
     port: REDIS_PORT
     # Prefix for the queue name
     prefix: REDIS_QUEUE_PREFIX
+    # Flag to enable client for TLS-based communication
+    tls: REDIS_TLS_ENABLED

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -47,4 +47,6 @@ redis:
     port: 6379
     # Prefix for the queue name
     # prefix: 'beta-'
+    # Flag to enable client for TLS-based communication
+    tls: false
 

--- a/config/redis.js
+++ b/config/redis.js
@@ -7,7 +7,8 @@ const connectionDetails = {
     pkg: 'ioredis',
     host: redisConfig.host,
     options: {
-        password: redisConfig.password
+        password: redisConfig.password,
+        tls: redisConfig.tls
     },
     port: redisConfig.port,
     database: 0

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -55,7 +55,8 @@ describe('Jobs Unit Test', () => {
             const expectedPort = 6379;
             const expectedHost = '127.0.0.1';
             const expectedOptions = {
-                password: undefined
+                password: undefined,
+                tls: false
             };
 
             assert.calledWith(mockRedis, expectedPort, expectedHost, expectedOptions);

--- a/test/redis.test.js
+++ b/test/redis.test.js
@@ -23,7 +23,8 @@ describe('redis config test', () => {
                 host: 'mockhost',
                 port: '1234',
                 password: 'SUPER_SECURE_PASSWORD',
-                prefix: 'mockPrefix_'
+                prefix: 'mockPrefix_',
+                tls: false
             })
         };
 
@@ -39,7 +40,8 @@ describe('redis config test', () => {
                 pkg: 'ioredis',
                 host: 'mockhost',
                 options: {
-                    password: 'SUPER_SECURE_PASSWORD'
+                    password: 'SUPER_SECURE_PASSWORD',
+                    tls: false
                 },
                 port: '1234',
                 database: 0


### PR DESCRIPTION
## Context

Although the Redis server may have a TLS proxy in front of it, the clients must also be configured to communicate to it via TLS. This change allows a configuration flag to be available for cluster maintainers to enable this feature.

This feature does _NOT_ support self-signed certificates.

## Objective

Allow a flag for configuring the Redis client to communicate with the Redis server via TLS.

## References

* Executor-related change: screwdriver-cd/screwdriver#797