### PR TITLE
fix: Stop builds in executor-jenkins

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -61,8 +61,21 @@ function start(buildConfig, callback) {
  * @param {Function}   callback                   Callback fn(error, result)
  */
 function stop(buildConfig, callback) {
-    return redis.hdel(`${queuePrefix}buildConfigs`, buildConfig.buildId)
-        .then(() => executor.stop(buildConfig))
+    const stopConfig = { buildId: buildConfig.buildId };
+
+    return redis.hget(`${queuePrefix}buildConfigs`, buildConfig.buildId)
+        .then((fullBuildConfig) => {
+            const parsedConfig = JSON.parse(fullBuildConfig);
+
+            if (parsedConfig && parsedConfig.annotations) {
+                stopConfig.annotations = parsedConfig.annotations;
+            }
+
+            return redis.hdel(`${queuePrefix}buildConfigs`, buildConfig.buildId);
+        }, (err) => {
+            winston.error('err in stop job: failed to get build config', err);
+        })
+        .then(() => executor.stop(stopConfig))
         .then(result => callback(null, result), err => callback(err));
 }
 

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "request": "^2.81.0",
     "screwdriver-executor-docker": "^2.2.2",
     "screwdriver-executor-jenkins": "^2.0.0",
-    "screwdriver-executor-k8s": "^10.3.4",
-    "screwdriver-executor-k8s-vm": "^2.0.0",
+    "screwdriver-executor-k8s": "^10.4.1",
+    "screwdriver-executor-k8s-vm": "^2.0.1",
     "screwdriver-executor-router": "^1.0.1",
     "winston": "^2.3.1"
   },

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -139,23 +139,61 @@ describe('Jobs Unit Test', () => {
         );
 
         it('stops a job', () => {
-            const expectedConfig = { buildConfig: 'buildConfig' };
+            const expectedConfig = {
+                annotations: {
+                    'beta.screwdriver.cd/executor': 'k8s'
+                },
+                buildId: 8609,
+                container: 'node:4',
+                apiUri: 'http://api.com',
+                token: 'asdf'
+            };
 
             mockExecutor.stop.resolves(null);
+            mockRedisObj.hget.resolves(JSON.stringify(expectedConfig));
             mockRedisObj.hdel.resolves(1);
 
-            return jobs.stop.perform(expectedConfig, (err, result) => {
+            return jobs.stop.perform({ buildId: expectedConfig.buildId }, (err, result) => {
                 assert.isNull(err);
                 assert.isNull(result);
 
+                assert.calledWith(mockRedisObj.hget, 'buildConfigs', expectedConfig.buildId);
                 assert.calledWith(mockRedisObj.hdel, 'buildConfigs', expectedConfig.buildId);
-                assert.calledWith(mockExecutor.stop, expectedConfig);
+                assert.calledWith(mockExecutor.stop, {
+                    annotations: expectedConfig.annotations,
+                    buildId: expectedConfig.buildId
+                });
+            });
+        });
+
+        it('stop a build anyway when redis fails to get a config', () => {
+            const expectedConfig = {
+                annotations: {
+                    'beta.screwdriver.cd/executor': 'k8s'
+                },
+                buildId: 8609,
+                container: 'node:4',
+                apiUri: 'http://api.com',
+                token: 'asdf'
+            };
+            const expectedError = new Error('hget error');
+
+            mockExecutor.stop.resolves(null);
+            mockRedisObj.hget.rejects(expectedError);
+
+            return jobs.stop.perform({ buildId: expectedConfig.buildId }, (err, result) => {
+                assert.isNull(err);
+                assert.isNull(result);
+
+                assert.calledWith(mockRedisObj.hget, 'buildConfigs', expectedConfig.buildId);
+                assert.calledWith(mockExecutor.stop, { buildId: expectedConfig.buildId });
             });
         });
 
         it('returns an error from stopping executor', () => {
             const expectedError = new Error('executor.stop Error');
 
+            mockRedisObj.hget.resolves('{}');
             mockRedisObj.hdel.resolves(1);
             mockExecutor.stop.rejects(expectedError);
 
@@ -167,6 +205,7 @@ describe('Jobs Unit Test', () => {
         it('returns an error when redis fails to remove a config', () => {
             const expectedError = new Error('hdel error');
 
+            mockRedisObj.hget.resolves('{}');
             mockRedisObj.hdel.rejects(expectedError);
 
             return jobs.stop.perform({}, (err) => {


### PR DESCRIPTION
### Context
For now, queue-worker doesn't pass annotations to a executor-router to stop builds, so the executor-router always uses a default executor.
https://github.com/screwdriver-cd/queue-worker/blob/bf09ec8133e21c6a3da77a118583b3bb380597ac/lib/jobs.js#L56-L65

executor-k8s and executor-k8s-vm are using same `stop` operation, so that it's not an issue. 
But executor-jenkins can't stop builds now.

### Objective
Before `redis.hdel`, execute `redis.hget` to get annotations.  
If `redist.hget` fails, queue-worker try to stop anyway.

At the same time, update executor-k8s and executor-k8s-vm version to take in some fixes.