### PR TITLE
fix: use new workflow and dependency on executor-k8s-vm

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,19 +1,16 @@
-workflow:
-    - publish
-    - beta
-    - prod
-
 shared:
     image: node:6
 
 jobs:
     main:
+        requires: [~pr, ~commit, ~sd@235:publish]
         steps:
             - install: npm install
             - test: npm test
 
     # Publish the package to GitHub and build docker image
     publish:
+        requires: [main]
         template: screwdriver-cd/semantic-release 
         steps:
             - postpublish: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci && ./ci/docker.sh
@@ -30,6 +27,7 @@ jobs:
 
     # Deploy to beta environment
     beta:
+        requires: [publish]
         steps:
             - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
             - get-tag: ./ci/git-latest.sh
@@ -48,6 +46,7 @@ jobs:
 
     # Deploy to our prod environment and run tests
     prod:
+        requires: [beta]
         steps:
             - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
             - get-tag: ./ci/git-latest.sh


### PR DESCRIPTION
## Objective

Pull in new version of executor-k8s-vm and update workflow

## References

Pulls in https://github.com/screwdriver-cd/executor-k8s-vm/pull/19