### PR TITLE
feat: Add Prometheus pushgateway environment variable

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -93,6 +93,8 @@ ecosystem:
     api: ECOSYSTEM_API
     # Externally routable URL for the Artifact Store
     store: ECOSYSTEM_STORE
+    # Pushgateway URL for Prometheus
+    pushgatewayUrl: ECOSYSTEM_PUSHGATEWAY_URL
 
 redis:
     # Host of redis cluster


### PR DESCRIPTION
## Context

It would be convenient if users could specify a URL to send executor data to their metric services.

## Objective

Add an example of `metricHost` usage in `default.yaml` and read an environment variable, `ECOSYSTEM_METRIC_HOST`, in `custom-environment-variables.yaml`.

## References

Merge for executor-k8s-vm implementation: https://github.com/screwdriver-cd/executor-k8s-vm/pull/24