### PR TITLE
feat: update executor-k8s & executor-k8s-vm strategies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "request": "^2.81.0",
     "screwdriver-executor-docker": "^2.2.2",
     "screwdriver-executor-jenkins": "^2.0.0",
-    "screwdriver-executor-k8s": "^10.4.3",
-    "screwdriver-executor-k8s-vm": "^2.1.1",
+    "screwdriver-executor-k8s": "^10.7.0",
+    "screwdriver-executor-k8s-vm": "^2.2.0",
     "screwdriver-executor-router": "^1.0.1",
     "winston": "^2.3.1"
   },


### PR DESCRIPTION
## Context

Both the `executor-k8s-vm` and `executor-k8s` plugins have been updated to refer to an annotation for users to configure build timeouts in their pipeline. By including this update in the `queue-worker`, we can enable users access to this feature.

## Objective

Update both the `executor-k8s-vm` and `executor-k8s` strategies to include the ability to use annotations for users to customize their build timeouts.

## References

* Feature issue
   * https://github.com/screwdriver-cd/screwdriver/issues/545
* `executor-k8s` PR that introduces the annotations update
   * https://github.com/screwdriver-cd/executor-k8s/pull/73
* `executor-k8s-vm` PR that introduces the annotations update
   * https://github.com/screwdriver-cd/executor-k8s-vm/pull/25