### PR TITLE
fix: build timeout measured in minutes

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "request": "^2.81.0",
     "screwdriver-executor-docker": "^2.2.2",
     "screwdriver-executor-jenkins": "^2.0.0",
-    "screwdriver-executor-k8s": "^10.7.0",
-    "screwdriver-executor-k8s-vm": "^2.2.0",
+    "screwdriver-executor-k8s": "^10.7.2",
+    "screwdriver-executor-k8s-vm": "^2.2.1",
     "screwdriver-executor-router": "^1.0.1",
     "winston": "^2.3.1"
   },


### PR DESCRIPTION
## Context

Both the `executor-k8s-vm` and `executor-k8s` plugins have been patched to refer to `build-timeout` in minutes instead of seconds.

## Objective

Update both the `executor-k8s-vm` and `executor-k8s` strategies to pull in the patched Launcher interface.

## References

* Feature issue
   * https://github.com/screwdriver-cd/screwdriver/issues/545
* `executor-k8s` PR
   * https://github.com/screwdriver-cd/executor-k8s/pull/75
* `executor-k8s-vm` PR
   * https://github.com/screwdriver-cd/executor-k8s-vm/pull/26