### PR TITLE
feat(996): rename to K8S_VM_NODE_SELECTORS for worker

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -65,12 +65,12 @@ executor:
             # Eg: { dedicated: 'screwdriver' } to schedule pods on nodes having
             # label-value of dedicated=screwdriver
             nodeSelectors:
-              __name: K8S_NODE_SELECTORS
+              __name: K8S_VM_NODE_SELECTORS
               __format: json
             # k8s preferred node selectors for build pod scheduling
             # See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
             preferredNodeSelectors:
-              __name: K8S_PREFERRED_NODE_SELECTORS
+              __name: K8S_VM_PREFERRED_NODE_SELECTORS
               __format: json
         # Launcher container tag to use
         launchVersion: LAUNCH_VERSION


### PR DESCRIPTION
We cannot set other selectors if we want to use other selectors with multiple executors (i.e. k8s and k8s-vm).
This PR fixes this problem.

Related: https://github.com/screwdriver-cd/screwdriver/issues/996.