### PR TITLE
fix(hip): Update to node:8

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "screwdriver-executor-docker": "^2.2.2",
     "screwdriver-executor-jenkins": "^2.0.0",
     "screwdriver-executor-k8s": "^10.4.3",
-    "screwdriver-executor-k8s-vm": "^2.0.3",
+    "screwdriver-executor-k8s-vm": "^2.1.1",
     "screwdriver-executor-router": "^1.0.1",
     "winston": "^2.3.1"
   },

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:6
+    image: node:8
 
 jobs:
     main:
@@ -16,7 +16,7 @@ jobs:
     # Publish the package to GitHub and build docker image
     publish:
         requires: [main]
-        template: screwdriver-cd/semantic-release 
+        template: screwdriver-cd/semantic-release
         steps:
             - postpublish: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci && ./ci/docker.sh
         environment:


### PR DESCRIPTION
## Context

Node.js 6 is slowly becoming deprecated, with popular packages such as `semantic-release` no longer supporting it.

## Objective

* Change image in `screwdriver.yaml` to `node:8`