### PR TITLE
fix(545): cluster configurable build timeout

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -22,6 +22,10 @@ executor:
                 memory:
                     low: K8S_MEMORY_LOW
                     high: K8S_MEMORY_HIGH
+            # Default build timeout for all builds in this cluster
+            buildTimeout: K8S_BUILD_TIMEOUT
+            # Default max build timeout
+            maxBuildTimeout: K8S_MAX_BUILD_TIMEOUT
             # k8s node selectors for approprate build pod scheduling.
             # Value is Object of format { label: 'value' } See
             # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#step-one-attach-label-to-the-node
@@ -59,6 +63,10 @@ executor:
                 memory:
                     low: K8S_MEMORY_LOW
                     high: K8S_MEMORY_HIGH
+            # Default build timeout for all builds in this cluster
+            buildTimeout: K8S_VM_BUILD_TIMEOUT
+            # Default max build timeout
+            maxBuildTimeout: K8S_VM_MAX_BUILD_TIMEOUT
             # k8s node selectors for approprate build pod scheduling.
             # Value is Object of format { label: 'value' } See
             # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#step-one-attach-label-to-the-node

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -16,6 +16,10 @@ executor:
                     # Memory in GB
                     low: 2
                     high: 12
+            # Default build timeout for all builds in this cluster
+            buildTimeout: 90
+            # Default max build timeout
+            maxBuildTimeout: 120
             # k8s node selectors for approprate pod scheduling
             nodeSelectors: {}
             preferredNodeSelectors: {}
@@ -37,6 +41,10 @@ executor:
                     # Memory in GB
                     low: 2
                     high: 12
+            # Default build timeout for all builds in this cluster
+            buildTimeout: 90
+            # Default max build timeout
+            maxBuildTimeout: 120
             # k8s node selectors for approprate pod scheduling
             nodeSelectors: {}
             preferredNodeSelectors: {}
@@ -68,4 +76,3 @@ redis:
     # prefix: 'beta-'
     # Flag to enable client for TLS-based communication
     tls: false
-


### PR DESCRIPTION
Allow admin to configure default build timeout 

Related: https://github.com/screwdriver-cd/screwdriver/issues/545