### PR TITLE
fix: use toolbox

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -18,7 +18,7 @@ jobs:
         requires: [main]
         template: screwdriver-cd/semantic-release
         steps:
-            - postpublish: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci && ./ci/docker.sh
+            - postpublish: git clone https://github.com/screwdriver-cd/toolbox.git ci && ./ci/docker-trigger.sh
         environment:
             # Docker hub repo
             DOCKER_REPO: screwdrivercd/queue-worker
@@ -34,7 +34,7 @@ jobs:
     beta:
         requires: [publish]
         steps:
-            - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
+            - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - get-tag: ./ci/git-latest.sh
             - wait-docker: DOCKER_TAG=`cat VERSION` ./ci/docker-wait.sh
             - deploy-k8s: K8S_TAG=`cat VERSION` ./ci/k8s-deploy.sh
@@ -53,7 +53,7 @@ jobs:
     prod:
         requires: [beta]
         steps:
-            - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
+            - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - get-tag: ./ci/git-latest.sh
             - wait-docker: DOCKER_TAG=`cat VERSION` ./ci/docker-wait.sh
             - deploy-k8s: K8S_TAG=`cat VERSION` ./ci/k8s-deploy.sh

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -18,7 +18,7 @@ jobs:
         requires: [main]
         template: screwdriver-cd/semantic-release
         steps:
-            - postpublish: git clone https://github.com/screwdriver-cd/toolbox.git ci && ./ci/docker-trigger.sh
+            - postpublish: git clone https://github.com/screwdriver-cd/toolbox.git ci && ./ci/git-latest.sh && DOCKER_TAG=`cat VERSION` ./ci/docker-trigger.sh
         environment:
             # Docker hub repo
             DOCKER_REPO: screwdrivercd/queue-worker


### PR DESCRIPTION
switching to use toolbox
`gitversion` was changed to support `darwin` and `linux`: https://github.com/screwdriver-cd/gitversion/commit/2ce30c16614d6e305f43a1dc7c2e52068b6aafaa, so the package name is now different. 
However, in the gist, it's still trying to look for `gitversion` as the name. Therefore, builds are failing: https://cd.screwdriver.cd/pipelines/301/builds/21433