### PR TITLE
fix: update requires

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -8,7 +8,8 @@ jobs:
         # ~sd@19:publish screwdriver-executor-jenkins https://cd.screwdriver.cd/pipelines/19
         # ~sd@28:publish screwdriver-executor-k8s https://cd.screwdriver.cd/pipelines/28
         # ~sd@202:publish screwdriver-executor-router https://cd.screwdriver.cd/pipelines/202
-        requires: [~pr, ~commit, ~sd@235:publish, ~sd@13:publish, ~sd@28:publish, ~sd@202:publish, ~sd@19:publish]
+        # requires: [~pr, ~commit, ~sd@235:publish, ~sd@13:publish, ~sd@28:publish, ~sd@202:publish, ~sd@19:publish]
+        requires: [~pr, ~commit]
         steps:
             - install: npm install
             - test: npm test


### PR DESCRIPTION
It doesn't really make sense to have these in `requires` since this repo has `semantic-release`, the build will fail since it cannot find a "new change": https://cd.screwdriver.cd/pipelines/301

Comment out the line instead of removing completely so that next time when we re-visit we don't need to go back to find all the pipelineId again. 