### PR TITLE
fix(hip): Update screwdriver dependencies that use node:8

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "screwdriver-executor-docker": "^2.2.2",
     "screwdriver-executor-jenkins": "^2.0.0",
     "screwdriver-executor-k8s": "^10.4.3",
-    "screwdriver-executor-k8s-vm": "^2.0.3",
+    "screwdriver-executor-k8s-vm": "^2.1.1",
     "screwdriver-executor-router": "^1.0.1",
     "winston": "^2.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "node-resque": "^4.0.7",
     "request": "^2.81.0",
     "screwdriver-executor-docker": "^2.2.2",
-    "screwdriver-executor-jenkins": "^2.0.0",
-    "screwdriver-executor-k8s": "^10.9.1",
+    "screwdriver-executor-jenkins": "^3.0.0",
+    "screwdriver-executor-k8s": "^11.1.0",
     "screwdriver-executor-k8s-vm": "^2.3.1",
     "screwdriver-executor-router": "^1.0.1",
     "winston": "^2.3.1"


### PR DESCRIPTION
## Context

Some Screwdriver dependencies have been updated to use Node.js 8 features, such as `async/await`. Since this change is breaking (`node:6` doesn't support it), these dependencies need to be updated manually.

## Objective

* Update any dependencies that had a major version bump due to `node:8` upgrades