### PR TITLE
Implement startDelayed() to execute delayed jobs

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -38,10 +38,10 @@ const retryOptions = {
 };
 
 /**
- * Post a new build event with the jobConfig obtained from the redis database
+ * Call executor.startPeriodic with the jobConfig obtained from the redis database
  * @method startDelayed
- * @param {Object}    buildConfig               Configuration object
- * @param {String}    buildConfig.buildId       Unique ID for a build
+ * @param {Object}    jobConfig                 Configuration object
+ * @param {String}    jobConfig.jobId           Unique ID for a job
  * @param {Function}  callback                  Callback fn(error, result)
  */
 function startDelayed(jobConfig, callback) {

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -46,9 +46,9 @@ const retryOptions = {
  */
 function startDelayed(jobConfig, callback) {
     return redis.hget(`${queuePrefix}periodicBuilds`, jobConfig.jobId)
-        .then(fullConfig => executor.startPeriodic(fullConfig, true))
+        .then(fullConfig => executor.startPeriodic(JSON.parse(fullConfig), true))
         .then(result => callback(null, result), (err) => {
-            winston.error('err in start job: ', err);
+            winston.error('err in startDelayed job: ', err);
             callback(err);
         });
 }

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -38,6 +38,22 @@ const retryOptions = {
 };
 
 /**
+ * Post a new build event with the jobConfig obtained from the redis database
+ * @method startDelayed
+ * @param {Object}    buildConfig               Configuration object
+ * @param {String}    buildConfig.buildId       Unique ID for a build
+ * @param {Function}  callback                  Callback fn(error, result)
+ */
+function startDelayed(jobConfig, callback) {
+    return redis.hget(`${queuePrefix}periodicBuilds`, jobConfig.jobId)
+        .then(fullConfig => executor.startPeriodic(fullConfig, true))
+        .then(result => callback(null, result), (err) => {
+            winston.error('err in start job: ', err);
+            callback(err);
+        });
+}
+
+/**
  * Call executor.start with the buildConfig obtained from the redis database
  * @method start
  * @param {Object}    buildConfig               Configuration object
@@ -82,5 +98,6 @@ function stop(buildConfig, callback) {
 
 module.exports = {
     start: Object.assign({ perform: start }, retryOptions),
-    stop: Object.assign({ perform: stop }, retryOptions)
+    stop: Object.assign({ perform: stop }, retryOptions),
+    startDelayed: Object.assign({ perform: startDelayed }, retryOptions)
 };


### PR DESCRIPTION
# Context

The executor-queue enqueues a delayed job in the queue to invoke _startDelayed_(), which is implemented in this PR. The function gets the job config from redis and passes it back on the the executor's _startPeriodic_ function.

# Objective

- [x] Implement a function _startDelayed_() that can call executor-queue's _startPeriodic_() with a job configuration obtained from redis.
- [x] Unit tests.

# Related links

API PR - https://github.com/screwdriver-cd/screwdriver/pull/1032
Models PR - https://github.com/screwdriver-cd/models/pull/239
Queue Worker PR - https://github.com/screwdriver-cd/queue-worker/pull/57
Executor Base PR - https://github.com/screwdriver-cd/executor-base/pull/39