### PR TITLE
fix: require blockedby correctly

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -3,7 +3,7 @@
 const Redis = require('ioredis');
 const config = require('config');
 const winston = require('winston');
-const BlockedBy = require('./BlockedBy');
+const BlockedBy = require('./BlockedBy').BlockedBy;
 const ExecutorRouter = require('screwdriver-executor-router');
 const { connectionDetails, queuePrefix, runningJobsPrefix } = require('../config/redis');
 

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -55,7 +55,9 @@ describe('Jobs Unit Test', () => {
         mockRedis = sinon.stub().returns(mockRedisObj);
         mockery.registerMock('ioredis', mockRedis);
 
-        mockBlockedBy = sinon.stub().returns();
+        mockBlockedBy = {
+            BlockedBy: sinon.stub().returns()
+        };
         mockery.registerMock('./BlockedBy', mockBlockedBy);
 
         // eslint-disable-next-line global-require
@@ -87,7 +89,7 @@ describe('Jobs Unit Test', () => {
     describe('start', () => {
         it('constructs start job correctly', () =>
             assert.deepEqual(jobs.start, {
-                plugins: ['Retry', mockBlockedBy],
+                plugins: ['Retry', mockBlockedBy.BlockedBy],
                 pluginOptions: {
                     Retry: {
                         retryLimit: 3,


### PR DESCRIPTION
Currently getting: 
```
Plugin must be the constructor name or an object null [object Object]
```
