### PR TITLE
fix: Make sure events are sequential, Allow blocked by options to be configurable.

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -137,3 +137,10 @@ redis:
     prefix: REDIS_QUEUE_PREFIX
     # Flag to enable client for TLS-based communication
     tls: REDIS_TLS_ENABLED
+
+plugins:
+    blockedBy:
+        # re-enqueue in _ mins if blocked
+        reenqueueWaitTime: PLUGIN_BLOCKEDBY_REENQUEUE_WAIT_TIME
+        # job is blocking for maximum _ mins
+        blockTimeout: PLUGIN_BLOCKEDBY_BLOCK_TIMEOUT

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -80,3 +80,9 @@ redis:
     # prefix: 'beta-'
     # Flag to enable client for TLS-based communication
     tls: false
+plugins:
+    blockedby:
+      # re-enqueue in 2 mins if blocked
+      reenqueueWaitTime: 2
+      # job is blocking for maximum 120 mins = build timeout
+      blockTimeout: 120

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -81,7 +81,7 @@ redis:
     # Flag to enable client for TLS-based communication
     tls: false
 plugins:
-    blockedby:
+    blockedBy:
       # re-enqueue in 2 mins if blocked
       reenqueueWaitTime: 2
       # job is blocking for maximum 120 mins = build timeout

--- a/config/redis.js
+++ b/config/redis.js
@@ -17,9 +17,11 @@ const queuePrefix = redisConfig.prefix || '';
 
 // Use for blockedby plugin
 const runningJobsPrefix = `${queuePrefix}running_job_`;
+const waitingJobsPrefix = `${queuePrefix}waiting_job_`;
 
 module.exports = {
     connectionDetails,
     queuePrefix,
-    runningJobsPrefix
+    runningJobsPrefix,
+    waitingJobsPrefix
 };

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -19,7 +19,6 @@ class BlockedBy extends NodeResque.Plugin {
             `${runningJobsPrefix}${jid}`);
         const blockingJobKeys = await this.queueObject.connection.redis.mget(blockedBy);
         const blockingJobsRunning = blockingJobKeys.some(j => j !== null);
-        const sameJobWaiting = await this.queueObject.connection.redis.llen(waitingKey);
 
         // If any blocking job is running, then re-enqueue
         if (blockingJobsRunning) {
@@ -27,6 +26,8 @@ class BlockedBy extends NodeResque.Plugin {
 
             return false;
         }
+
+        let sameJobWaiting = await this.queueObject.connection.redis.llen(waitingKey);
 
         // If not blocking, but the same job is already waiting
         if (sameJobWaiting > 0) {
@@ -47,8 +48,9 @@ class BlockedBy extends NodeResque.Plugin {
         // Pop the first waiting build
         await this.queueObject.connection.redis.lpop(waitingKey);
 
-        // Delete the waiting key
-        if (sameJobWaiting === 1) {
+        // Get the waiting jobs again - to prevent race condition where this value is changed in between
+        sameJobWaiting = await this.queueObject.connection.redis.llen(waitingKey);
+        if (sameJobWaiting === 0) {
             await this.queueObject.connection.redis.del(waitingKey);
         }
 
@@ -78,9 +80,15 @@ class BlockedBy extends NodeResque.Plugin {
      * @return {Promise}
      */
     async reEnqueue(waitingKey, buildId) {
+        const buildsWaiting = await this.queueObject.connection.redis.lrange(waitingKey, 0, -1);
+        const keyExist = buildsWaiting.some(key => parseInt(key, 10) === buildId);
+
         // Add the current buildId to the waiting list of this job
         // Looks like jobID: buildID buildID buildID
-        await this.queueObject.connection.redis.rpush(waitingKey, buildId);
+        if (!keyExist) {
+            await this.queueObject.connection.redis.rpush(waitingKey, buildId);
+        }
+
         // enqueueIn uses milliseconds
         await this.queueObject.enqueueIn(
             this.reenqueueWaitTime() * 1000 * 60, this.queue, this.func, this.args);

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -5,8 +5,9 @@ const { runningJobsPrefix, waitingJobsPrefix } = require('../config/redis');
 
 class BlockedBy extends NodeResque.Plugin {
     /**
-     * Checks if there are any blocking jobs running. If yes, re-enqueue
-     * If no, set the current job ID as key
+     * Checks if there are any blocking jobs running.
+     * If yes, re-enqueue. If no, check if there is the same job waiting.
+     * If buildId is not the same, re-enqueue. Otherwise, proceeds and set the current job as running
      * @method beforePerform
      * @return {Promise}
      */

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -29,7 +29,7 @@ class BlockedBy extends NodeResque.Plugin {
         // Set expire time to take care of the case where
         // afterPerform failed to call and blocked jobs will be stuck forever
         await this.queueObject.connection.redis.set(key, '');
-        await this.queueObject.connection.redis.expire(key, this.lockTimeout());
+        await this.queueObject.connection.redis.expire(key, this.blockTimeout() * 60);
 
         // Proceed
         return true;
@@ -50,16 +50,17 @@ class BlockedBy extends NodeResque.Plugin {
      * @return {Promise}
      */
     async reEnqueue() {
+        // enqueueIn uses milliseconds
         await this.queueObject.enqueueIn(
-            this.reenqueueWaitTime() * 1000, this.queue, this.func, this.args);
+            this.reenqueueWaitTime() * 1000 * 60, this.queue, this.func, this.args);
     }
 
-    lockTimeout() { // same as build timeout
-        if (this.options.lockTimeout) {
-            return this.options.lockTimeout;
+    blockTimeout() { // same as build timeout
+        if (this.options.blockTimeout) {
+            return this.options.blockTimeout;
         }
 
-        return 7200; // in seconds
+        return 120; // in minutes
     }
 
     reenqueueWaitTime() {
@@ -67,7 +68,7 @@ class BlockedBy extends NodeResque.Plugin {
             return this.options.reenqueueWaitTime;
         }
 
-        return 300; // in seconds
+        return 2; // in minutes
     }
 }
 

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const NodeResque = require('node-resque');
-const { runningJobsPrefix } = require('../config/redis');
+const { runningJobsPrefix, waitingJobsPrefix } = require('../config/redis');
 
 class BlockedBy extends NodeResque.Plugin {
     /**
@@ -11,25 +11,52 @@ class BlockedBy extends NodeResque.Plugin {
      * @return {Promise}
      */
     async beforePerform() {
-        const jobId = this.args[0].jobId;
+        const { jobId, buildId } = this.args[0];
+        const runningKey = `${runningJobsPrefix}${jobId}`;
+        const waitingKey = `${waitingJobsPrefix}${jobId}`;
         const blockedBy = this.args[0].blockedBy.split(',').map(jid =>
             `${runningJobsPrefix}${jid}`);
         const blockingJobKeys = await this.queueObject.connection.redis.mget(blockedBy);
         const blockingJobsRunning = blockingJobKeys.some(j => j !== null);
-        const key = `${runningJobsPrefix}${jobId}`;
+        const sameJobWaiting = await this.queueObject.connection.redis.llen(waitingKey);
 
         // If any blocking job is running, then re-enqueue
         if (blockingJobsRunning) {
-            await this.reEnqueue();
+            await this.reEnqueue(waitingKey, buildId);
 
             return false;
         }
 
+        // If not blocking, but the same job is already waiting
+        if (sameJobWaiting > 0) {
+            // get the first build that is waiting
+            let firstWaitingBuild = await this.queueObject.connection.redis.lindex(waitingKey, 0);
+
+            firstWaitingBuild = parseInt(firstWaitingBuild, 10);
+
+            // if it's not the first build waiting, then re-enqueue
+            if (firstWaitingBuild !== buildId) {
+                await this.reEnqueue(waitingKey, buildId);
+
+                return false;
+            }
+        }
+
+        // Proceed to run build
+        // Pop the first waiting build
+        await this.queueObject.connection.redis.lpop(waitingKey);
+
+        // Delete the waiting key
+        if (sameJobWaiting === 1) {
+            await this.queueObject.connection.redis.del(waitingKey);
+        }
+
         // Register the curent job as running by setting key
+        await this.queueObject.connection.redis.set(runningKey, '');
+
         // Set expire time to take care of the case where
         // afterPerform failed to call and blocked jobs will be stuck forever
-        await this.queueObject.connection.redis.set(key, '');
-        await this.queueObject.connection.redis.expire(key, this.blockTimeout() * 60);
+        await this.queueObject.connection.redis.expire(runningKey, this.blockTimeout() * 60);
 
         // Proceed
         return true;
@@ -49,7 +76,10 @@ class BlockedBy extends NodeResque.Plugin {
      * @method reEnqueue
      * @return {Promise}
      */
-    async reEnqueue() {
+    async reEnqueue(waitingKey, buildId) {
+        // Add the current buildId to the waiting list of this job
+        // Looks like jobID: buildID buildID buildID
+        await this.queueObject.connection.redis.rpush(waitingKey, buildId);
         // enqueueIn uses milliseconds
         await this.queueObject.enqueueIn(
             this.reenqueueWaitTime() * 1000 * 60, this.queue, this.func, this.args);

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -9,8 +9,9 @@ const { connectionDetails, queuePrefix, runningJobsPrefix } = require('../config
 
 const RETRY_LIMIT = 3;
 const RETRY_DELAY = 5;
-const LOCK_TIMEOUT = 7200;
-const REENQUEUE_WAIT_TIME = 300;
+
+const blockTimeout = config.get('plugins').blockedby.blockTimeout;
+const reenqueueWaitTime = config.get('plugins').blockedby.reenqueueWaitTime;
 
 const redis = new Redis(connectionDetails.port, connectionDetails.host, connectionDetails.options);
 
@@ -91,10 +92,10 @@ module.exports = {
             BlockedBy: {
                 // TTL of key, same value as build timeout so that
                 // blocked job is not stuck forever in the case cleanup failed to run
-                lockTimeout: LOCK_TIMEOUT,
+                blockTimeout,
 
                 // Time to reEnqueue
-                reenqueueWaitTime: REENQUEUE_WAIT_TIME
+                reenqueueWaitTime
             }
         },
         perform: start

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -4,15 +4,12 @@ const Redis = require('ioredis');
 const config = require('config');
 const winston = require('winston');
 const BlockedBy = require('./BlockedBy').BlockedBy;
+const blockedByConfig = config.get('plugins').blockedBy;
 const ExecutorRouter = require('screwdriver-executor-router');
 const { connectionDetails, queuePrefix, runningJobsPrefix } = require('../config/redis');
 
 const RETRY_LIMIT = 3;
 const RETRY_DELAY = 5;
-
-const blockTimeout = config.get('plugins').blockedby.blockTimeout;
-const reenqueueWaitTime = config.get('plugins').blockedby.reenqueueWaitTime;
-
 const redis = new Redis(connectionDetails.port, connectionDetails.host, connectionDetails.options);
 
 const ecosystem = config.get('ecosystem');
@@ -34,6 +31,14 @@ const executor = new ExecutorRouter({
 const retryOptions = {
     retryLimit: RETRY_LIMIT,
     retryDelay: RETRY_DELAY
+};
+const blockedByOptions = {
+    // TTL of key, same value as build timeout so that
+    // blocked job is not stuck forever in the case cleanup failed to run
+    blockTimeout: blockedByConfig.blockTimeout,
+
+    // Time to reEnqueue
+    reenqueueWaitTime: blockedByConfig.reenqueueWaitTime
 };
 
 /**
@@ -89,14 +94,7 @@ module.exports = {
         plugins: ['Retry', BlockedBy],
         pluginOptions: {
             Retry: retryOptions,
-            BlockedBy: {
-                // TTL of key, same value as build timeout so that
-                // blocked job is not stuck forever in the case cleanup failed to run
-                blockTimeout,
-
-                // Time to reEnqueue
-                reenqueueWaitTime
-            }
+            BlockedBy: blockedByOptions
         },
         perform: start
     },

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -96,8 +96,8 @@ describe('Jobs Unit Test', () => {
                         retryDelay: 5
                     },
                     BlockedBy: {
-                        reenqueueWaitTime: 300,
-                        lockTimeout: 7200
+                        reenqueueWaitTime: 2,
+                        blockTimeout: 120
                     }
                 },
                 perform: jobs.start.perform

--- a/test/redis.test.js
+++ b/test/redis.test.js
@@ -47,7 +47,8 @@ describe('redis config test', () => {
                 database: 0
             },
             queuePrefix: 'mockPrefix_',
-            runningJobsPrefix: 'mockPrefix_running_job_'
+            runningJobsPrefix: 'mockPrefix_running_job_',
+            waitingJobsPrefix: 'mockPrefix_waiting_job_'
         });
     });
 


### PR DESCRIPTION
Address the edge case described below:
- User starts A1
- User starts A2 - get blocked by itself -> reenqueue in 2 mins
- A1 finishes 
- User starts A3 - not blocked -> start A3
- 2 mins passed. A2 is enqueued -> start A2

Therefore, the events will be out of order: A1->A3->A2. This PR fixes it by having each waiting job as a list `waitingjob_jobId` with the members is the `buildId`

For example: `waiting_job_A` has `build2` (event A2) as its member. When A3/build3 comes, it will check `build3 !== build2`, so it will reenqueue. Then when A2/build2 comes, it checkes `build2 === build2`, so it will start the build. 

Also in this PR:
- Switch unit to mins instead of secs
- Allow the options to be configurable

Follow up of: https://github.com/screwdriver-cd/queue-worker/pull/60

Related: https://github.com/screwdriver-cd/screwdriver/issues/653
