### PR TITLE
fix: add blockedby name

### DIFF
--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -5,6 +5,16 @@ const { runningJobsPrefix, waitingJobsPrefix } = require('../config/redis');
 
 class BlockedBy extends NodeResque.Plugin {
     /**
+   * Construct a new BlockedBy plugin
+   * @method constructor
+   */
+    constructor(worker, func, queue, job, args, options) {
+        super(worker, func, queue, job, args, options);
+
+        this.name = 'BlockedBy';
+    }
+
+    /**
      * Checks if there are any blocking jobs running.
      * If yes, re-enqueue. If no, check if there is the same job waiting.
      * If buildId is not the same, re-enqueue. Otherwise, proceeds and set the current job as running

--- a/test/blockedBy.test.js
+++ b/test/blockedBy.test.js
@@ -81,6 +81,10 @@ describe('Plugin Test', () => {
     });
 
     describe('BlockedBy', () => {
+        it('constructor', async () => {
+            assert.equal(blockedBy.name, 'BlockedBy');
+        });
+
         describe('beforePerform', () => {
             it('proceeds if not blocked', async () => {
                 await blockedBy.beforePerform();


### PR DESCRIPTION
I noticed that the plugin did not take in the plugin options and just use the default value for `reenqueueWaitTime` and `blockTimeout`.
I looked into their code here: https://github.com/taskrabbit/node-resque/blob/master/lib/pluginRunner.js#L24-L36
It looks like they construct a new plugin, then get the `pluginName`, and then use the `pluginName` to get the `pluginOptions`. However, inside their constructor, `pluginName` is hardcoded to `CustomPlugin`: https://github.com/taskrabbit/node-resque/blob/master/lib/plugin.js#L5
Very strange! I'm a little confused on how their own plugin options could work. But from the code it looks like we need to override the plugin name . 