### PR TITLE
fix: decrease enqueue time

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -82,7 +82,7 @@ redis:
     tls: false
 plugins:
     blockedBy:
-      # re-enqueue in 2 mins if blocked
-      reenqueueWaitTime: 2
+      # re-enqueue in 1 mins if blocked
+      reenqueueWaitTime: 1
       # job is blocking for maximum 120 mins = build timeout
       blockTimeout: 120

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -117,7 +117,7 @@ class BlockedBy extends NodeResque.Plugin {
             return this.options.reenqueueWaitTime;
         }
 
-        return 2; // in minutes
+        return 1; // in minutes
     }
 }
 

--- a/test/blockedBy.test.js
+++ b/test/blockedBy.test.js
@@ -8,7 +8,7 @@ sinon.assert.expose(assert, { prefix: '' });
 
 describe('Plugin Test', () => {
     const DEFAULT_BLOCKTIMEOUT = 120;
-    const DEFAULT_ENQUEUETIME = 2;
+    const DEFAULT_ENQUEUETIME = 1;
     const jobId = 777;
     const buildId = 3;
     const buildIdStr = '3';
@@ -166,7 +166,7 @@ describe('Plugin Test', () => {
             });
 
             it('use reenqueueWaitTime option for enqueueing', async () => {
-                const reenqueueWaitTime = 2;
+                const reenqueueWaitTime = 5;
 
                 mockRedis.mget.resolves([true, null]);
                 blockedBy = new BlockedBy(mockWorker, mockFunc, mockQueue, mockJob, mockArgs, {
@@ -175,7 +175,7 @@ describe('Plugin Test', () => {
 
                 await blockedBy.beforePerform();
                 assert.calledWith(mockWorker.queueObject.enqueueIn,
-                    120000, mockQueue, mockFunc, mockArgs);
+                    300000, mockQueue, mockFunc, mockArgs);
             });
         });
 

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -96,7 +96,7 @@ describe('Jobs Unit Test', () => {
                         retryDelay: 5
                     },
                     BlockedBy: {
-                        reenqueueWaitTime: 2,
+                        reenqueueWaitTime: 1,
                         blockTimeout: 120
                     }
                 },


### PR DESCRIPTION
The previous fix (https://github.com/screwdriver-cd/queue-worker/pull/64) worked! 
I'm just setting the value to default so I don't need to change it in our deployment. 