### PR TITLE
fix: node-resque@5.3.1 is broken

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "config": "^1.26.1",
     "ioredis": "^3.1.4",
-    "node-resque": "^5.3.0",
+    "node-resque": "5.3.0",
     "request": "^2.86.0",
     "screwdriver-executor-docker": "^2.3.4",
     "screwdriver-executor-jenkins": "^3.0.0",


### PR DESCRIPTION
I found that node-resque@5.3.1 does not handle redis auth properly and 5.3.0 works fine, so I pinned the version of node-resque to 5.3.0.

queue-worker@1.12.0 + node-resque@**5.3.0**
```
> screwdriver-queue-worker@1.12.0 start /usr/src/app/node_modules/screwdriver-queue-worker
> node index.js

info: *** checked for worker status: x (event loop delay: Infinityms)
info: scheduler started
info: worker[1] started
info: worker[1] polling builds
info: *** checked for worker status: + (event loop delay: 2ms)
info: worker[1] paused
info: *** checked for worker status: x (event loop delay: 1ms)
```

queue-worker@1.12.0 + node-resque@**5.3.1**
```
> screwdriver-queue-worker@1.12.0 start /usr/src/app/node_modules/screwdriver-queue-worker
> node index.js

info: *** checked for worker status: x (event loop delay: Infinityms)
info: scheduler started
info: scheduler error >> ReplyError: NOAUTH Authentication required.
info: scheduler error >> ReplyError: NOAUTH Authentication required.
info: scheduler error >> ReplyError: NOAUTH Authentication required.
info: scheduler error >> ReplyError: NOAUTH Authentication required.
info: scheduler error >> ReplyError: NOAUTH Authentication required.
```