### PR TITLE
fix: set buildId as value

### DIFF
--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -65,7 +65,7 @@ class BlockedBy extends NodeResque.Plugin {
         }
 
         // Register the curent job as running by setting key
-        await this.queueObject.connection.redis.set(runningKey, '');
+        await this.queueObject.connection.redis.set(runningKey, buildId);
 
         // Set expire time to take care of the case where
         // afterPerform failed to call and blocked jobs will be stuck forever

--- a/test/blockedBy.test.js
+++ b/test/blockedBy.test.js
@@ -89,7 +89,7 @@ describe('Plugin Test', () => {
             it('proceeds if not blocked', async () => {
                 await blockedBy.beforePerform();
                 assert.calledWith(mockRedis.mget, blockedByKeys);
-                assert.calledWith(mockRedis.set, key, '');
+                assert.calledWith(mockRedis.set, key, buildId);
                 assert.calledWith(mockRedis.expire, key, DEFAULT_BLOCKTIMEOUT * 60);
                 assert.notCalled(mockWorker.queueObject.enqueueIn);
             });
@@ -136,7 +136,7 @@ describe('Plugin Test', () => {
                 mockRedis.lindex.resolves('3');
                 await blockedBy.beforePerform();
                 assert.calledWith(mockRedis.mget, blockedByKeys);
-                assert.calledWith(mockRedis.set, key, '');
+                assert.calledWith(mockRedis.set, key, buildId);
                 assert.calledWith(mockRedis.expire, key, DEFAULT_BLOCKTIMEOUT * 60);
                 assert.notCalled(mockWorker.queueObject.enqueueIn);
             });
@@ -147,7 +147,7 @@ describe('Plugin Test', () => {
                 mockRedis.llen.onCall(1).resolves(0);
                 await blockedBy.beforePerform();
                 assert.calledWith(mockRedis.mget, blockedByKeys);
-                assert.calledWith(mockRedis.set, key, '');
+                assert.calledWith(mockRedis.set, key, buildId);
                 assert.calledWith(mockRedis.lpop, `${waitingJobsPrefix}${jobId}`);
                 assert.calledWith(mockRedis.del, `${waitingJobsPrefix}${jobId}`);
                 assert.calledWith(mockRedis.expire, key, DEFAULT_BLOCKTIMEOUT * 60);


### PR DESCRIPTION
So we know exactly which build is running