### PR TITLE
fix: sort waiting values

### DIFF
--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -37,34 +37,33 @@ class BlockedBy extends NodeResque.Plugin {
             return false;
         }
 
-        let sameJobWaiting = await this.queueObject.connection.redis.llen(waitingKey);
+        let waitingBuilds = await this.queueObject.connection.redis.lrange(waitingKey, 0, -1);
 
-        // If not blocking, but the same job is already waiting
-        if (sameJobWaiting > 0) {
-            let waitingBuilds = await this.queueObject.connection.redis.lrange(waitingKey, 0, -1);
-
+        // Only need to do this if there are waiting builds.
+        // If it's not the first build waiting, then re-enqueue
+        if (waitingBuilds.length > 0) {
             waitingBuilds = waitingBuilds.map(bId => parseInt(bId, 10));
             waitingBuilds.sort((a, b) => a - b);
 
-            // get the first build that is waiting
+            // Get the first build that is waiting
             const firstWaitingBuild = waitingBuilds[0];
 
-            // if it's not the first build waiting, then re-enqueue
             if (firstWaitingBuild !== buildId) {
                 await this.reEnqueue(waitingKey, buildId);
 
                 return false;
             }
-        }
 
-        // Proceed to run build
-        // Pop the first waiting build
-        await this.queueObject.connection.redis.lpop(waitingKey);
+            // If is the first waiting build, remove it and proceed
+            await this.queueObject.connection.redis.lrem(waitingKey, 0, firstWaitingBuild);
 
-        // Get the waiting jobs again - to prevent race condition where this value is changed in between
-        sameJobWaiting = await this.queueObject.connection.redis.llen(waitingKey);
-        if (sameJobWaiting === 0) {
-            await this.queueObject.connection.redis.del(waitingKey);
+            // Get the waiting jobs again - to prevent race condition where this value is changed in between
+            const sameJobWaiting = await this.queueObject.connection.redis.llen(waitingKey);
+
+            // Remove the waiting key
+            if (sameJobWaiting === 0) {
+                await this.queueObject.connection.redis.del(waitingKey);
+            }
         }
 
         // Register the curent job as running by setting key

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -41,10 +41,13 @@ class BlockedBy extends NodeResque.Plugin {
 
         // If not blocking, but the same job is already waiting
         if (sameJobWaiting > 0) {
-            // get the first build that is waiting
-            let firstWaitingBuild = await this.queueObject.connection.redis.lindex(waitingKey, 0);
+            let waitingBuilds = await this.queueObject.connection.redis.lrange(waitingKey, 0, -1);
 
-            firstWaitingBuild = parseInt(firstWaitingBuild, 10);
+            waitingBuilds = waitingBuilds.map(bId => parseInt(bId, 10));
+            waitingBuilds.sort((a, b) => a - b);
+
+            // get the first build that is waiting
+            const firstWaitingBuild = waitingBuilds[0];
 
             // if it's not the first build waiting, then re-enqueue
             if (firstWaitingBuild !== buildId) {

--- a/test/blockedBy.test.js
+++ b/test/blockedBy.test.js
@@ -46,7 +46,8 @@ describe('Plugin Test', () => {
             lpop: sinon.stub().resolves(),
             lrange: sinon.stub().resolves(['4', '5']),
             rpush: sinon.stub().resolves(),
-            del: sinon.stub().resolves()
+            del: sinon.stub().resolves(),
+            lrem: sinon.stub().resolves()
         };
         mockWorker = {
             queueObject: {
@@ -86,6 +87,7 @@ describe('Plugin Test', () => {
 
         describe('beforePerform', () => {
             it('proceeds if not blocked', async () => {
+                mockRedis.lrange.resolves([]);
                 await blockedBy.beforePerform();
                 assert.calledWith(mockRedis.mget, blockedByKeys);
                 assert.calledWith(mockRedis.set, key, buildId);
@@ -118,8 +120,8 @@ describe('Plugin Test', () => {
             });
 
             it('re-enqueue if there is the same job waiting but not the same buildId', async () => {
-                mockRedis.llen.resolves(1);
                 mockRedis.lrange.resolves(['2']);
+                mockRedis.llen.resolves(1);
                 await blockedBy.beforePerform();
                 assert.calledWith(mockRedis.mget, blockedByKeys);
                 assert.notCalled(mockRedis.set);
@@ -131,8 +133,8 @@ describe('Plugin Test', () => {
             });
 
             it('proceeds if there is the same job waiting with same buildId', async () => {
-                mockRedis.llen.resolves(2);
                 mockRedis.lrange.resolves(['5', '3', '4']);
+                mockRedis.llen.resolves(2);
                 await blockedBy.beforePerform();
                 assert.calledWith(mockRedis.mget, blockedByKeys);
                 assert.calledWith(mockRedis.set, key, buildId);
@@ -141,19 +143,19 @@ describe('Plugin Test', () => {
             });
 
             it('delete key if is the last job waiting', async () => {
-                mockRedis.llen.onCall(0).resolves(1);
-                mockRedis.llen.onCall(1).resolves(0);
                 mockRedis.lrange.resolves(['3']);
+                mockRedis.llen.resolves(0);
                 await blockedBy.beforePerform();
                 assert.calledWith(mockRedis.mget, blockedByKeys);
                 assert.calledWith(mockRedis.set, key, buildId);
-                assert.calledWith(mockRedis.lpop, `${waitingJobsPrefix}${jobId}`);
+                assert.calledWith(mockRedis.lrem, `${waitingJobsPrefix}${jobId}`, 0, 3);
                 assert.calledWith(mockRedis.del, `${waitingJobsPrefix}${jobId}`);
                 assert.calledWith(mockRedis.expire, key, DEFAULT_BLOCKTIMEOUT * 60);
                 assert.notCalled(mockWorker.queueObject.enqueueIn);
             });
 
             it('use lockTimeout option for expiring key', async () => {
+                mockRedis.lrange.resolves([]);
                 const blockTimeout = 1;
 
                 blockedBy = new BlockedBy(mockWorker, mockFunc, mockQueue, mockJob, mockArgs, {


### PR DESCRIPTION
I noticed the waiting values are not always sorted. This might help with getting the correct first waiting build. It's unclear why the values are not sorted. 

```
lrange "waiting_job_14528" 0 -1
1) "136634"
2) "136730"
3) "136715"
4) "136712"
5) "136608"
6) "136644"
7) "136753"
8) "136788"
9) "136991"
```