### PR TITLE
fix: use string for flag because of k8s

### DIFF
--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -28,7 +28,7 @@ class BlockedBy extends NodeResque.Plugin {
         let blockedBy = this.args[0].blockedBy.split(',').map(jid =>
             `${runningJobsPrefix}${jid}`);
 
-        if (!this.options.blockedBySelf) {
+        if (String(this.options.blockedBySelf) === 'false') { // because kubernete value is a string
             blockedBy = blockedBy.filter(key => key !== `${runningJobsPrefix}${jobId}`);
         }
 

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -28,7 +28,7 @@ class BlockedBy extends NodeResque.Plugin {
         let blockedBy = this.args[0].blockedBy.split(',').map(jid =>
             `${runningJobsPrefix}${jid}`);
 
-        if (String(this.options.blockedBySelf) === 'false') { // because kubernete value is a string
+        if (String(this.options.blockedBySelf) === 'false') { // because kubernetes value is a string
             blockedBy = blockedBy.filter(key => key !== `${runningJobsPrefix}${jobId}`);
         }
 

--- a/test/blockedBy.test.js
+++ b/test/blockedBy.test.js
@@ -100,7 +100,7 @@ describe('Plugin Test', () => {
             it('do not block by self', async () => {
                 mockRedis.lrange.resolves([]);
                 blockedBy = new BlockedBy(mockWorker, mockFunc, mockQueue, mockJob, mockArgs, {
-                    blockedBySelf: false
+                    blockedBySelf: 'false'
                 });
 
                 await blockedBy.beforePerform();


### PR DESCRIPTION
Flag will come in as a string because of kubernetes