### PR TITLE
fix: do not call mget if not blocked

### DIFF
--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -32,14 +32,16 @@ class BlockedBy extends NodeResque.Plugin {
             blockedBy = blockedBy.filter(key => key !== `${runningJobsPrefix}${jobId}`);
         }
 
-        const blockingJobKeys = await this.queueObject.connection.redis.mget(blockedBy);
-        const blockingJobsRunning = blockingJobKeys.some(j => j !== null);
+        if (blockedBy.length > 0) {
+            const blockingJobKeys = await this.queueObject.connection.redis.mget(blockedBy);
+            const blockingJobsRunning = blockingJobKeys.some(j => j !== null);
 
-        // If any blocking job is running, then re-enqueue
-        if (blockingJobsRunning) {
-            await this.reEnqueue(waitingKey, buildId);
+            // If any blocking job is running, then re-enqueue
+            if (blockingJobsRunning) {
+                await this.reEnqueue(waitingKey, buildId);
 
-            return false;
+                return false;
+            }
         }
 
         let waitingBuilds = await this.queueObject.connection.redis.lrange(waitingKey, 0, -1);


### PR DESCRIPTION
Only call `mget` when `blockedBy` is there. 
Previously, we always have `blockedBy`, but with flag turns off, this could be an empty array. And `mget` gives some issues. Seems like we need to check if the array length >0 first. 
Similar code here: https://github.com/taskrabbit/node-resque/blob/1b8509651bf5962b987cce2de819cd1d2c9576b7/lib/queue.js#L181-L183