### PR TITLE
fix: also wrap waiting key check

### DIFF
--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -73,6 +73,8 @@ class BlockedBy extends NodeResque.Plugin {
                     await this.queueObject.connection.redis.del(waitingKey);
                 }
             }
+        } else { // clean up waitingKey
+            await this.queueObject.connection.redis.del(waitingKey);
         }
 
         // Register the curent job as running by setting key

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -29,7 +29,7 @@ class BlockedBy extends NodeResque.Plugin {
             `${runningJobsPrefix}${jid}`);
 
         if (String(this.options.blockedBySelf) === 'false') { // because kubernetes value is a string
-            blockedBy = blockedBy.filter(key => key !== `${runningJobsPrefix}${jobId}`);
+            blockedBy = blockedBy.filter(key => key !== `${runningJobsPrefix}${jobId}`); // remove itself from blocking list
         }
 
         if (blockedBy.length > 0) {
@@ -44,32 +44,34 @@ class BlockedBy extends NodeResque.Plugin {
             }
         }
 
-        let waitingBuilds = await this.queueObject.connection.redis.lrange(waitingKey, 0, -1);
+        if (String(this.options.blockedBySelf) === 'true') { // only check this if feature is on
+            let waitingBuilds = await this.queueObject.connection.redis.lrange(waitingKey, 0, -1);
 
-        // Only need to do this if there are waiting builds.
-        // If it's not the first build waiting, then re-enqueue
-        if (waitingBuilds.length > 0) {
-            waitingBuilds = waitingBuilds.map(bId => parseInt(bId, 10));
-            waitingBuilds.sort((a, b) => a - b);
+            // Only need to do this if there are waiting builds.
+            // If it's not the first build waiting, then re-enqueue
+            if (waitingBuilds.length > 0) {
+                waitingBuilds = waitingBuilds.map(bId => parseInt(bId, 10));
+                waitingBuilds.sort((a, b) => a - b);
 
-            // Get the first build that is waiting
-            const firstWaitingBuild = waitingBuilds[0];
+                // Get the first build that is waiting
+                const firstWaitingBuild = waitingBuilds[0];
 
-            if (firstWaitingBuild !== buildId) {
-                await this.reEnqueue(waitingKey, buildId);
+                if (firstWaitingBuild !== buildId) {
+                    await this.reEnqueue(waitingKey, buildId);
 
-                return false;
-            }
+                    return false;
+                }
 
-            // If is the first waiting build, remove it and proceed
-            await this.queueObject.connection.redis.lrem(waitingKey, 0, firstWaitingBuild);
+                // If is the first waiting build, remove it and proceed
+                await this.queueObject.connection.redis.lrem(waitingKey, 0, firstWaitingBuild);
 
-            // Get the waiting jobs again - to prevent race condition where this value is changed in between
-            const sameJobWaiting = await this.queueObject.connection.redis.llen(waitingKey);
+                // Get the waiting jobs again - to prevent race condition where this value is changed in between
+                const sameJobWaiting = await this.queueObject.connection.redis.llen(waitingKey);
 
-            // Remove the waiting key
-            if (sameJobWaiting === 0) {
-                await this.queueObject.connection.redis.del(waitingKey);
+                // Remove the waiting key
+                if (sameJobWaiting === 0) {
+                    await this.queueObject.connection.redis.del(waitingKey);
+                }
             }
         }
 

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -3,6 +3,45 @@
 const NodeResque = require('node-resque');
 const { runningJobsPrefix, waitingJobsPrefix } = require('../config/redis');
 
+/**
+ * Handle blocked by itself
+ * @method blockedBySelf
+ * @param  {String}      waitingKey     ${waitingJobsPrefix}${jobId}
+ * @param  {String}      buildId        Current buildId
+ * @return {Boolean}                    Whether this build is blocked
+ */
+async function blockedBySelf({ waitingKey, buildId }) {
+    let waitingBuilds = await this.queueObject.connection.redis.lrange(waitingKey, 0, -1);
+
+    // Only need to do this if there are waiting builds.
+    // If it's not the first build waiting, then re-enqueue
+    if (waitingBuilds.length > 0) {
+        waitingBuilds = waitingBuilds.map(bId => parseInt(bId, 10));
+        waitingBuilds.sort((a, b) => a - b);
+
+        // Get the first build that is waiting
+        const firstWaitingBuild = waitingBuilds[0];
+
+        if (firstWaitingBuild !== buildId) {
+            await this.reEnqueue(waitingKey, buildId);
+
+            return true; // blocked
+        }
+
+        // If is the first waiting build, remove it and proceed
+        await this.queueObject.connection.redis.lrem(waitingKey, 0, firstWaitingBuild);
+
+        // Get the waiting jobs again - to prevent race condition where this value is changed in between
+        const sameJobWaiting = await this.queueObject.connection.redis.llen(waitingKey);
+
+        // Remove the waiting key
+        if (sameJobWaiting === 0) {
+            await this.queueObject.connection.redis.del(waitingKey);
+        }
+    }
+
+    return false;
+}
 class BlockedBy extends NodeResque.Plugin {
     /**
    * Construct a new BlockedBy plugin
@@ -45,34 +84,12 @@ class BlockedBy extends NodeResque.Plugin {
         }
 
         if (String(this.options.blockedBySelf) === 'true') { // only check this if feature is on
-            let waitingBuilds = await this.queueObject.connection.redis.lrange(waitingKey, 0, -1);
+            const blocked = await blockedBySelf.call(this, { // pass in this context
+                waitingKey,
+                buildId
+            });
 
-            // Only need to do this if there are waiting builds.
-            // If it's not the first build waiting, then re-enqueue
-            if (waitingBuilds.length > 0) {
-                waitingBuilds = waitingBuilds.map(bId => parseInt(bId, 10));
-                waitingBuilds.sort((a, b) => a - b);
-
-                // Get the first build that is waiting
-                const firstWaitingBuild = waitingBuilds[0];
-
-                if (firstWaitingBuild !== buildId) {
-                    await this.reEnqueue(waitingKey, buildId);
-
-                    return false;
-                }
-
-                // If is the first waiting build, remove it and proceed
-                await this.queueObject.connection.redis.lrem(waitingKey, 0, firstWaitingBuild);
-
-                // Get the waiting jobs again - to prevent race condition where this value is changed in between
-                const sameJobWaiting = await this.queueObject.connection.redis.llen(waitingKey);
-
-                // Remove the waiting key
-                if (sameJobWaiting === 0) {
-                    await this.queueObject.connection.redis.del(waitingKey);
-                }
-            }
+            if (blocked) { return false; } // if blocked then cannot proceed
         } else { // clean up waitingKey
             await this.queueObject.connection.redis.del(waitingKey);
         }

--- a/test/blockedBy.test.js
+++ b/test/blockedBy.test.js
@@ -159,6 +159,7 @@ describe('Plugin Test', () => {
                 });
                 blockedByKeys = [`${runningJobsPrefix}111`, `${runningJobsPrefix}222`];
                 await blockedBy.beforePerform();
+                assert.calledWith(mockRedis.del, `${waitingJobsPrefix}${jobId}`);
                 assert.calledWith(mockRedis.mget, blockedByKeys);
                 assert.calledWith(mockRedis.mget, blockedByKeys);
                 assert.calledWith(mockRedis.set, key, buildId);


### PR DESCRIPTION
Technically shouldn't get to this stage if starting from fresh. 
But since `redis` might consist some leftover data, it can get to this stage. 