### PR TITLE
 fix: Clean up jobs that were aborted while queued

### DIFF
--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const NodeResque = require('node-resque');
-const { runningJobsPrefix, waitingJobsPrefix } = require('../config/redis');
+const { runningJobsPrefix, waitingJobsPrefix, deletingJobsPrefix } = require('../config/redis');
 
 /**
  * Handle blocked by itself
@@ -64,6 +64,27 @@ class BlockedBy extends NodeResque.Plugin {
         const { jobId, buildId } = this.args[0];
         const runningKey = `${runningJobsPrefix}${jobId}`;
         const waitingKey = `${waitingJobsPrefix}${jobId}`;
+        const deleteKey = `${deletingJobsPrefix}${jobId}${buildId}`;
+        const shouldDelete = await this.queueObject.connection.redis.get(deleteKey);
+
+        // If this build is in the delete list (it was aborted)
+        if (shouldDelete) {
+            await this.queueObject.connection.redis.del(deleteKey);
+
+            //  Clean up to prevent race condtion: stop and beforePerform happen at the same time
+            //  stop deletes key runningKey and waitingKey
+            //  beforePerform either proceeds or reEnqueue (which adds the key back)
+            await this.queueObject.connection.redis.lrem(waitingKey, 0, buildId);
+            const runningBuildId = await this.queueObject.connection.redis.get(runningKey);
+
+            if (runningBuildId === buildId) {
+                await this.queueObject.connection.redis.del(runningKey);
+            }
+
+            // Should not proceed since this build was previously aborted
+            return false;
+        }
+
         let blockedBy = this.args[0].blockedBy.split(',').map(jid =>
             `${runningJobsPrefix}${jid}`);
 

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const NodeResque = require('node-resque');
-const { runningJobsPrefix, waitingJobsPrefix, deletingJobsPrefix } = require('../config/redis');
+const { runningJobsPrefix, waitingJobsPrefix } = require('../config/redis');
 
 /**
  * Handle blocked by itself
@@ -64,7 +64,8 @@ class BlockedBy extends NodeResque.Plugin {
         const { jobId, buildId } = this.args[0];
         const runningKey = `${runningJobsPrefix}${jobId}`;
         const waitingKey = `${waitingJobsPrefix}${jobId}`;
-        const deleteKey = `${deletingJobsPrefix}${jobId}${buildId}`;
+        const deleteKey = `deleted_${jobId}_${buildId}`;
+        const enforceBlockedBySelf = String(this.options.blockedBySelf) === 'true'; // because kubernetes value is a string
         const shouldDelete = await this.queueObject.connection.redis.get(deleteKey);
 
         // If this build is in the delete list (it was aborted)
@@ -88,7 +89,7 @@ class BlockedBy extends NodeResque.Plugin {
         let blockedBy = this.args[0].blockedBy.split(',').map(jid =>
             `${runningJobsPrefix}${jid}`);
 
-        if (String(this.options.blockedBySelf) === 'false') { // because kubernetes value is a string
+        if (!enforceBlockedBySelf) {
             blockedBy = blockedBy.filter(key => key !== `${runningJobsPrefix}${jobId}`); // remove itself from blocking list
         }
 
@@ -104,7 +105,7 @@ class BlockedBy extends NodeResque.Plugin {
             }
         }
 
-        if (String(this.options.blockedBySelf) === 'true') { // only check this if feature is on
+        if (enforceBlockedBySelf) { // only check this if feature is on
             const blocked = await blockedBySelf.call(this, { // pass in this context
                 waitingKey,
                 buildId

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -69,16 +69,16 @@ class BlockedBy extends NodeResque.Plugin {
         const shouldDelete = await this.queueObject.connection.redis.get(deleteKey);
 
         // If this build is in the delete list (it was aborted)
-        if (shouldDelete) {
+        if (shouldDelete !== null) {
             await this.queueObject.connection.redis.del(deleteKey);
 
-            //  Clean up to prevent race condtion: stop and beforePerform happen at the same time
+            //  Clean up to prevent race condition: stop and beforePerform happen at the same time
             //  stop deletes key runningKey and waitingKey
             //  beforePerform either proceeds or reEnqueue (which adds the key back)
             await this.queueObject.connection.redis.lrem(waitingKey, 0, buildId);
             const runningBuildId = await this.queueObject.connection.redis.get(runningKey);
 
-            if (runningBuildId === buildId) {
+            if (parseInt(runningBuildId, 10) === buildId) {
                 await this.queueObject.connection.redis.del(runningKey);
             }
 


### PR DESCRIPTION
Return `false` to not run the job when it's in the delete list.
Clean up the keys. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/1110

