### PR TITLE
fix: bump node-resque version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "config": "^1.26.1",
     "ioredis": "^3.1.4",
-    "node-resque": "5.3.0",
+    "node-resque": "^5.3.2",
     "request": "^2.86.0",
     "screwdriver-executor-docker": "^2.3.4",
     "screwdriver-executor-jenkins": "^3.0.0",


### PR DESCRIPTION
I updated the version of node-resque.
`v5.3.2` should include the fix of #68.

Ref: https://github.com/taskrabbit/node-resque/pull/246