### PR TITLE
fix: move cleanup to worker stop

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -3,6 +3,7 @@
 const Redis = require('ioredis');
 const config = require('config');
 const winston = require('winston');
+const hoek = require('hoek');
 const BlockedBy = require('./BlockedBy').BlockedBy;
 const blockedByConfig = config.get('plugins').blockedBy;
 const ExecutorRouter = require('screwdriver-executor-router');
@@ -70,9 +71,11 @@ function start(buildConfig) {
  * @param  {String}    buildConfig.buildId       Unique ID for a build
  * @param  {String}    buildConfig.jobId         Job that this build belongs to
  * @param  {String}    buildConfig.blockedBy     Jobs that are blocking this job
+ * @param  {String}    buildConfig.started       Whether job has started
  * @return {Promise}
  */
 function stop(buildConfig) {
+    const started = hoek.reach(buildConfig, 'started', { default: true }); // default value for backward compatibility
     const { buildId, jobId } = buildConfig;
     const stopConfig = { buildId };
 
@@ -92,7 +95,7 @@ function stop(buildConfig) {
         .then(() => redis.del(`${runningJobsPrefix}${jobId}`))
         // If this is a waiting job
         .then(() => redis.lrem(`${waitingJobsPrefix}${jobId}`, 0, buildId))
-        .then(() => executor.stop(stopConfig));
+        .then(() => (started ? executor.stop(stopConfig) : null));
 }
 
 module.exports = {

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -78,6 +78,7 @@ function stop(buildConfig) {
     const started = hoek.reach(buildConfig, 'started', { default: true }); // default value for backward compatibility
     const { buildId, jobId } = buildConfig;
     const stopConfig = { buildId };
+    const runningKey = `${runningJobsPrefix}${jobId}`;
 
     return redis.hget(`${queuePrefix}buildConfigs`, buildId)
         .then((fullBuildConfig) => {
@@ -92,7 +93,14 @@ function stop(buildConfig) {
         })
         .then(() => redis.hdel(`${queuePrefix}buildConfigs`, buildId))
         // If this is a running job
-        .then(() => redis.del(`${runningJobsPrefix}${jobId}`))
+        .then(() => redis.get(runningKey))
+        .then((runningBuildId) => {
+            if (parseInt(runningBuildId, 10) === buildId) {
+                return redis.del(runningKey);
+            }
+
+            return null;
+        })
         // If this is a waiting job
         .then(() => redis.lrem(`${waitingJobsPrefix}${jobId}`, 0, buildId))
         .then(() => (started ? executor.stop(stopConfig) : null));

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "config": "^1.26.1",
+    "hoek": "^5.0.3",
     "ioredis": "^3.1.4",
     "node-resque": "^5.3.2",
     "request": "^2.86.0",

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -47,6 +47,7 @@ describe('Jobs Unit Test', () => {
             hget: sinon.stub(),
             hdel: sinon.stub(),
             del: sinon.stub(),
+            get: sinon.stub(),
             lrem: sinon.stub().resolves()
         };
 
@@ -168,12 +169,13 @@ describe('Jobs Unit Test', () => {
             mockRedisObj.hget.resolves(JSON.stringify(fullConfig));
             mockRedisObj.hdel.resolves(1);
             mockRedisObj.del.resolves(null);
+            mockRedisObj.get.withArgs('running_job_777').resolves('1000');
 
             return jobs.stop.perform(stopConfig).then((result) => {
                 assert.isNull(result);
                 assert.calledWith(mockRedisObj.hget, 'buildConfigs', fullConfig.buildId);
                 assert.calledWith(mockRedisObj.hdel, 'buildConfigs', fullConfig.buildId);
-                assert.calledWith(mockRedisObj.del, 'running_job_777');
+                assert.notCalled(mockRedisObj.del);
                 assert.calledWith(mockRedisObj.lrem, 'waiting_job_777', 0, fullConfig.buildId);
                 assert.notCalled(mockExecutor.stop);
             });
@@ -184,6 +186,7 @@ describe('Jobs Unit Test', () => {
             mockRedisObj.hget.resolves(JSON.stringify(fullConfig));
             mockRedisObj.hdel.resolves(1);
             mockRedisObj.del.resolves(null);
+            mockRedisObj.get.withArgs('running_job_777').resolves(fullConfig.buildId);
 
             return jobs.stop.perform(partialConfig).then((result) => {
                 assert.isNull(result);


### PR DESCRIPTION
## Context
Previously, we addressed this case by adding `delete` key:
- Build is still in the queue and **picked up by worker**
- User aborts
- Executor-queue adds `delete` key, and call `stop` which cleans up `waiting` key 
- Worker puts back to queue
- Worker picks up same build again, in `beforePerform`, it does clean up and will not proceed. 

There is a new edge case scenario I found:
- Build is still in the queue and **not picked up by worker**
- User aborts
- Executor-queue removes it from queue, adds the `delete` key, `waiting` key remains
- Because it's removed from queue, it will not go to `beforePerform` to clean up. `waiting` key still contains this buildId, so subsequent builds cannot be started. 

## 
This PR moves all the clean up to worker stop. This will be called no matter what. If the build already started, it will make an extra call to `executor.stop`

Related: https://github.com/screwdriver-cd/screwdriver/issues/1110