### PR TITLE
fix: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install screwdriver-queue-worker
 
 ## Configuration
 
-Queue worker already [defaults most configuration](config/default.yaml), but you can override defaults using a `local.yaml` or environment variables using `custom-environment-variables.yaml`.
+Queue worker already [defaults most configuration](config/default.yaml), but you can override defaults using a `local.yaml` or environment variables using [custom-environment-variables.yaml](config/custom-environment-variables.yaml).
 
 ### Methods
 


### PR DESCRIPTION
Previous commit has Upper case `F` so semantic-release didn't recognize the change