### PR TITLE
feat: pull in log-service flag change. BREAKING CHANGE: interface cha…

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
     "ioredis": "^3.1.4",
     "node-resque": "^5.3.2",
     "request": "^2.86.0",
-    "screwdriver-executor-docker": "^2.3.4",
-    "screwdriver-executor-jenkins": "^3.0.0",
-    "screwdriver-executor-k8s": "^12.0.0",
+    "screwdriver-executor-docker": "^3.0.0",
+    "screwdriver-executor-jenkins": "^4.0.0",
+    "screwdriver-executor-k8s": "^13.0.0",
     "screwdriver-executor-k8s-vm": "^2.4.3",
     "screwdriver-executor-router": "^1.0.5",
     "winston": "^2.4.2"


### PR DESCRIPTION
pull in log-service flag change. BREAKING CHANGE: interface changes

**Note**: Please make sure you pull in this version of queue-worker together with env `LAUNCH_VERSION` set to `v5.0.1`

If you're using executor-k8s-vm, make sure your `K8S_BASE_IMAGE` is set to `screwdrivercd/hyperctl-image:v1.0.1`

Related to https://github.com/screwdriver-cd/screwdriver/issues/1114