### PR TITLE
feat: Add config for Jenkins build timeout

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -98,6 +98,10 @@ executor:
             password: EXECUTOR_JENKINS_PASSWORD
             # Node labels of Jenkins slaves
             nodeLabel: EXECUTOR_JENKINS_NODE_LABEL
+            # Default build timeout
+            buildTimeout: EXECUTOR_JENKINS_BUILD_TIMEOUT
+            # Default max build timeout
+            maxBuildTimeout: EXECUTOR_JENKINS_MAX_BUILD_TIMEOUT
         docker:
             # The path to the docker-compose command
             composeCommand: EXECUTOR_JENKINS_DOCKER_COMPOSE_COMMAND

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -62,6 +62,10 @@ executor:
 #             port: 8080
 #             username: screwdriver
 #             password: "WOW-AN-EVEN-MORE-INSECURE-PASSWORD!!!!"
+#             # Default build timeout (in minutes)
+#             buildTimeout: 90
+#             # Default max build timeout (in minutes)
+#             maxBuildTimeout: 120
 
 ecosystem:
     # Externally routable URL for the User Interface


### PR DESCRIPTION
## Context
Configurations for the Jenkins Executor's PR.

## Objective
Add the configurations for Jenkins build timeout.

## References
screwdriver/executor-jenkins PR: https://github.com/screwdriver-cd/executor-jenkins/pull/22
issue: https://github.com/screwdriver-cd/screwdriver/issues/1159