### PR TITLE
fix(818): add annotations to k8s config

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -41,6 +41,13 @@ executor:
             preferredNodeSelectors:
               __name: K8S_PREFERRED_NODE_SELECTORS
               __format: json
+            # k8s annotations
+            # Value is Object of format { key: 'value' } See
+            # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+            # Eg: {"io.kubernetes.cri.untrusted-workload": "true"}
+            annotations:
+              __name: K8S_ANNOTATIONS
+              __format: json
         # Launcher container tag to use
         launchVersion: LAUNCH_VERSION
         # Prefix to the pod

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -25,6 +25,7 @@ executor:
             # k8s node selectors for approprate pod scheduling
             nodeSelectors: {}
             preferredNodeSelectors: {}
+            annotations: {}
         # Container tags to use
         launchVersion: stable
     k8s-vm:


### PR DESCRIPTION
Allow cluster admin to inject annotations to build pod.

Related to https://github.com/screwdriver-cd/screwdriver/issues/818