### PR TITLE
feat(757): Add disk label as a configurable option

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -74,6 +74,8 @@ executor:
                     micro: K8S_MEMORY_MICRO
                     low: K8S_MEMORY_LOW
                     high: K8S_MEMORY_HIGH
+                disk:
+                  high: K8S_DISK_LABEL
             # Default build timeout for all builds in this cluster
             buildTimeout: K8S_VM_BUILD_TIMEOUT
             # Default max build timeout


### PR DESCRIPTION
## Context
executor-k8s-vm will consume the value of `options.kubernetes.resources.disk.high` and use it to set the toleration/node affinity of pods that require a high disk resource.

## Objective
Add `options.kubernetes.resources.disk.high` as a configurable option.

## References
https://github.com/screwdriver-cd/executor-k8s-vm/pull/42
https://github.com/screwdriver-cd/screwdriver/issues/757