### PR TITLE
fix: pull in new executor plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,24 +36,24 @@
   ],
   "devDependencies": {
     "chai": "^4.1.1",
-    "eslint": "^4.3.0",
-    "eslint-config-screwdriver": "^3.0.0",
+    "eslint": "^4.19.1",
+    "eslint-config-screwdriver": "^3.0.1",
     "jenkins-mocha": "^5.0.0",
     "mockery": "^2.1.0",
     "sinon": "^3.1.0"
   },
   "dependencies": {
-    "config": "^1.26.1",
-    "hoek": "^5.0.3",
-    "ioredis": "^3.1.4",
+    "config": "^1.31.0",
+    "hoek": "^5.0.4",
+    "ioredis": "^3.2.2",
     "node-resque": "^5.3.2",
-    "request": "^2.86.0",
+    "request": "^2.88.0",
     "screwdriver-executor-docker": "^3.2.0",
     "screwdriver-executor-jenkins": "^4.2.0",
     "screwdriver-executor-k8s": "^13.2.0",
     "screwdriver-executor-k8s-vm": "^2.5.1",
-    "screwdriver-executor-router": "^1.0.5",
-    "winston": "^2.4.2"
+    "screwdriver-executor-router": "^1.0.8",
+    "winston": "^2.4.4"
   },
   "release": {
     "debug": false,


### PR DESCRIPTION
pull in new executor plugins with parse annotation function and status msg in k8s and k8s-vm if no resources available.