### PR TITLE
fix: Pull in new executor plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "request": "^2.88.0",
     "screwdriver-executor-docker": "^3.2.0",
     "screwdriver-executor-jenkins": "^4.2.0",
-    "screwdriver-executor-k8s": "^13.2.0",
-    "screwdriver-executor-k8s-vm": "^2.5.1",
+    "screwdriver-executor-k8s": "^13.2.5",
+    "screwdriver-executor-k8s-vm": "^2.7.1",
     "screwdriver-executor-router": "^1.0.8",
     "winston": "^2.4.4"
   },


### PR DESCRIPTION
## Context
The latest `executor-k8s` and `executor-k8s-vm` plugins include changes to the `setNodeSelector` logic. This PR pulls them into the `queue-worker`.

## Objective
Pull in the latest `executor-k8s` and `executor-k8s-vm` plugins.

## References
https://github.com/screwdriver-cd/executor-k8s/pull/94
https://github.com/screwdriver-cd/executor-k8s-vm/pull/43