### PR TITLE
fix: log plugin object

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ async function boot() {
     multiWorker.on('job', (workerId, queue, job) =>
         winston.info(`worker[${workerId}] working job ${queue} ${JSON.stringify(job)}`));
     multiWorker.on('reEnqueue', (workerId, queue, job, plugin) =>
-        winston.info(`worker[${workerId}] reEnqueue job (${plugin}) ${queue} ${JSON.stringify(job)}`));
+        winston.info(`worker[${workerId}] reEnqueue job (${JSON.stringify(plugin)}) ${queue} ${JSON.stringify(job)}`));
     multiWorker.on('success', (workerId, queue, job, result) =>
         winston.info(`worker[${workerId}] ${job} success ${queue} ${JSON.stringify(job)} >> ${result}`));
     multiWorker.on('failure', (workerId, queue, job, failure) =>

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -11,7 +11,8 @@ const { connectionDetails, queuePrefix, runningJobsPrefix, waitingJobsPrefix }
 = require('../config/redis');
 
 const RETRY_LIMIT = 3;
-const RETRY_DELAY = 5;
+// This is in milliseconds, reference: https://github.com/taskrabbit/node-resque/blob/master/lib/plugins/Retry.js#L12
+const RETRY_DELAY = 5 * 1000;
 const redis = new Redis(connectionDetails.port, connectionDetails.host, connectionDetails.options);
 
 const ecosystem = config.get('ecosystem');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -158,6 +158,7 @@ describe('Index Test', () => {
 
             testWorker.emit('reEnqueue', workerId, queue, job, plugin);
             assert.calledWith(winstonMock.info,
+                // eslint-disable-next-line max-len
                 `worker[${workerId}] reEnqueue job (${JSON.stringify(plugin)}) ${queue} ${JSON.stringify(job)}`);
 
             testWorker.emit('success', workerId, queue, job, result);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -158,7 +158,7 @@ describe('Index Test', () => {
 
             testWorker.emit('reEnqueue', workerId, queue, job, plugin);
             assert.calledWith(winstonMock.info,
-                `worker[${workerId}] reEnqueue job (${plugin}) ${queue} ${JSON.stringify(job)}`);
+                `worker[${workerId}] reEnqueue job (${JSON.stringify(plugin)}) ${queue} ${JSON.stringify(job)}`);
 
             testWorker.emit('success', workerId, queue, job, result);
             assert.calledWith(winstonMock.info,

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -95,7 +95,7 @@ describe('Jobs Unit Test', () => {
                 pluginOptions: {
                     Retry: {
                         retryLimit: 3,
-                        retryDelay: 5
+                        retryDelay: 5000
                     },
                     BlockedBy: {
                         reenqueueWaitTime: 1,
@@ -155,7 +155,7 @@ describe('Jobs Unit Test', () => {
                 pluginOptions: {
                     Retry: {
                         retryLimit: 3,
-                        retryDelay: 5
+                        retryDelay: 5000
                     }
                 },
                 perform: jobs.stop.perform


### PR DESCRIPTION
this plugin object contains info about how many times already retried etc. currently it's showing like `[object Object]` since it's an object.