### PR TITLE
fix: pull in latest k8s-vm

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "screwdriver-executor-docker": "^3.2.0",
     "screwdriver-executor-jenkins": "^4.2.0",
     "screwdriver-executor-k8s": "^13.2.9",
-    "screwdriver-executor-k8s-vm": "^2.7.4",
+    "screwdriver-executor-k8s-vm": "^2.7.5",
     "screwdriver-executor-router": "^1.0.8",
     "winston": "^2.4.4"
   },


### PR DESCRIPTION
## Context

This PR pulls in the latest k8s-vm

## References

- https://github.com/screwdriver-cd/executor-k8s-vm/pull/47
- https://www.npmjs.com/package/screwdriver-executor-k8s-vm