### PR TITLE
fix: switch k8s deploy endpoint

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -46,7 +46,7 @@ jobs:
             DOCKER_REPO: screwdrivercd/queue-worker
             K8S_CONTAINER: screwdriver-redis-worker
             K8S_IMAGE: screwdrivercd/queue-worker
-            K8S_HOST: api.k8s.screwdriver.cd
+            K8S_HOST: api.ossd.k8s.screwdriver.cd
             K8S_DEPLOYMENT: redis-worker-beta
         secrets:
             # Talking to Kubernetes
@@ -65,7 +65,7 @@ jobs:
             DOCKER_REPO: screwdrivercd/queue-worker
             K8S_CONTAINER: screwdriver-redis-worker
             K8S_IMAGE: screwdrivercd/queue-worker
-            K8S_HOST: api.k8s.screwdriver.cd
+            K8S_HOST: api.ossd.k8s.screwdriver.cd
             K8S_DEPLOYMENT: redis-worker
         secrets:
             # Talking to Kubernetes


### PR DESCRIPTION
Previously we point `api.k8s.screwdriver.cd`  to the ips for `api.ossd.k8s.screwdriver.cd` in AWS route53. That means whenever we update the cluster, manual change is needed. Switch to the correct endpoint.