### PR TITLE
fix: switch to checkExchange because of permission

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -196,7 +196,5 @@ scheduler:
         protocol: RABBITMQ_PROTOCOL
         # Exchange / router name for rabbitmq
         exchange: RABBITMQ_EXCHANGE
-        # Exchange type for rabbitmq
-        exchangeType: RABBITMQ_EXCHANGE_TYPE
         # Virtual host to connect to
         vhost: RABBITMQ_VHOST

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -130,8 +130,6 @@ scheduler:
         protocol: amqp
         # Exchange / router name for rabbitmq
         exchange: build
-        # Exchange type for rabbitmq
-        exchangeType: topic
         # Virtual host to connect to
         vhost: /screwdriver
 

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -12,7 +12,7 @@ const ExecutorRouter = require('screwdriver-executor-router');
 const { connectionDetails, queuePrefix, runningJobsPrefix, waitingJobsPrefix }
 = require('../config/redis');
 const rabbitmqConf = require('../config/rabbitmq');
-const { amqpURI, exchange, exchangeType } = rabbitmqConf.getConfig();
+const { amqpURI, exchange } = rabbitmqConf.getConfig();
 
 const RETRY_LIMIT = 3;
 // This is in milliseconds, reference: https://github.com/taskrabbit/node-resque/blob/master/lib/plugins/Retry.js#L12
@@ -89,7 +89,7 @@ function schedule(job, buildConfig) {
         };
         const channelWrapper = getRabbitmqConn().createChannel({
             json: true,
-            setup: channel => channel.assertExchange(exchange, exchangeType)
+            setup: channel => channel.checkExchange(exchange)
         });
 
         winston.info('publishing msg to rabbitmq:', buildConfig.id);

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -75,8 +75,7 @@ describe('Jobs Unit Test', () => {
         mockRabbitmqConfigObj = {
             schedulerMode: false,
             amqpURI: 'amqp://localhost:5672',
-            exchange: 'build',
-            exchangeType: 'topic'
+            exchange: 'build'
         };
 
         mockRabbitmqConfig = {
@@ -316,7 +315,6 @@ describe('Jobs Unit Test', () => {
                 assert.calledWith(mockRedisObj.hget, 'buildConfigs', fullConfig.buildId);
                 assert.calledWith(mockAmqp.connect, [amqpURI]);
                 assert.calledOnce(mockRabbitmqConnection.createChannel);
-                // assert.calledWith(mockRabbitmqCh.assertExchange, exchange, exchangeType);
                 assert.calledWith(mockRabbitmqCh.publish, exchange, 'sd', msg, {
                     contentType: 'application/json', persistent: true
                 });


### PR DESCRIPTION
`assertExchange` requires `config` permission which we don't want to give for the producer. Switch to use `checkExchange` instead. 

Ref: https://www.squaremobius.net/amqp.node/channel_api.html#channel_checkExchange