### PR TITLE
fix: add disk speed label config [3]

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -87,6 +87,7 @@ executor:
                     turbo: K8S_MEMORY_TURBO
                 disk:
                   high: K8S_DISK_LABEL
+                  speed: K8S_DISK_SPEED_LABEL
             # Default build timeout for all builds in this cluster
             buildTimeout: K8S_VM_BUILD_TIMEOUT
             # Default max build timeout


### PR DESCRIPTION
- make disk speed label configurable via ENV 

Related to https://github.com/screwdriver-cd/executor-k8s-vm/pull/53