### PR TITLE
fix: add check for waitingKey right before collapse

### DIFF
--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -120,7 +120,11 @@ class BlockedBy extends NodeResque.Plugin {
         const enableCollapse = String(this.options.collapse) === 'true'; // because kubernetes value is a string
         const buildConfig = await this.queueObject.connection.redis.hget(
             `${queuePrefix}buildConfigs`, buildId);
+<<<<<<< HEAD
         const collapse = hoek.reach(JSON.parse(buildConfig),
+=======
+        const collapse = hoek.reach(buildConfig,
+>>>>>>> feat: add collapse feature
             'annotations>screwdriver.cd/collapseBuilds', { default: true, separator: '>' });
 
         // For retry logic: failed to create pod, so it will retry

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -36,13 +36,17 @@ async function collapseBuilds({ waitingKey, buildId, blockingBuildIds }) {
         winston.info('buildsToCollapse:', buildsToCollapse);
 
         const rmBuilds = buildsToCollapse.map(async (bId) => {
-            await this.queueObject.connection.redis.lrem(waitingKey, 0, bId);
-            await helper.updateBuildStatus({
-                redisInstance: this.queueObject.connection.redis,
-                buildId: bId,
-                status: 'COLLAPSED',
-                statusMessage: `Collapsed to build: ${buildId}`
-            }, () => {});
+            const count = await this.queueObject.connection.redis.lrem(waitingKey, 0, bId);
+
+            // if the build is no longer in the waiting queue, don't update its status to collapsed
+            if (count > 0) {
+                await helper.updateBuildStatus({
+                    redisInstance: this.queueObject.connection.redis,
+                    buildId: bId,
+                    status: 'COLLAPSED',
+                    statusMessage: `Collapsed to build: ${buildId}`
+                }, () => {});
+            }
         });
 
         await Promise.all(rmBuilds);
@@ -78,7 +82,11 @@ async function blockedBySelf({ waitingKey, buildId }) {
         }
 
         // If is the first waiting build, remove it and proceed
-        await this.queueObject.connection.redis.lrem(waitingKey, 0, firstWaitingBuild);
+        const count = await this.queueObject.connection.redis.lrem(
+            waitingKey, 0, firstWaitingBuild);
+
+        // Build collapsed already, do not proceed
+        if (count < 1) return true;
 
         // Get the waiting jobs again - to prevent race condition where this value is changed in between
         const sameJobWaiting = await this.queueObject.connection.redis.llen(waitingKey);

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -120,11 +120,7 @@ class BlockedBy extends NodeResque.Plugin {
         const enableCollapse = String(this.options.collapse) === 'true'; // because kubernetes value is a string
         const buildConfig = await this.queueObject.connection.redis.hget(
             `${queuePrefix}buildConfigs`, buildId);
-<<<<<<< HEAD
         const collapse = hoek.reach(JSON.parse(buildConfig),
-=======
-        const collapse = hoek.reach(buildConfig,
->>>>>>> feat: add collapse feature
             'annotations>screwdriver.cd/collapseBuilds', { default: true, separator: '>' });
 
         // For retry logic: failed to create pod, so it will retry

--- a/test/blockedBy.test.js
+++ b/test/blockedBy.test.js
@@ -208,6 +208,7 @@ describe('Plugin Test', () => {
                 });
                 mockRedis.get.withArgs(`${runningJobsPrefix}111`).resolves('123');
                 mockRedis.lrange.resolves(['2', '1']);
+                mockRedis.lrem.resolves(1);
                 helperMock.updateBuildStatus.yieldsAsync(null, {});
                 await blockedBy.beforePerform();
                 assert.equal(mockRedis.get.getCall(0).args[0], deleteKey);
@@ -233,6 +234,35 @@ describe('Plugin Test', () => {
                     statusMessage: 'Collapsed to build: 3'
                 });
                 assert.calledWith(helperMock.updateBuildStatus.thirdCall, {
+                    buildId,
+                    redisInstance: mockRedis,
+                    status: 'BLOCKED',
+                    statusMessage: 'Blocked by these running build(s): 123'
+                });
+            });
+
+            it('do not collapse build no longer in waiting queue if blocked', async () => {
+                blockedBy = new BlockedBy(mockWorker, mockFunc, mockQueue, mockJob, mockArgs, {
+                    blockedBySelf: true,
+                    collapse: true
+                });
+                mockRedis.get.withArgs(`${runningJobsPrefix}111`).resolves('123');
+                mockRedis.lrange.resolves(['2']);
+                mockRedis.lrem.resolves(0);
+                helperMock.updateBuildStatus.yieldsAsync(null, {});
+                await blockedBy.beforePerform();
+                assert.equal(mockRedis.get.getCall(0).args[0], deleteKey);
+                assert.equal(mockRedis.get.getCall(1).args[0], runningKey);
+                assert.equal(mockRedis.get.getCall(2).args[0], `${runningJobsPrefix}111`);
+                assert.equal(mockRedis.get.getCall(3).args[0], `${runningJobsPrefix}222`);
+                assert.notCalled(mockRedis.set);
+                assert.notCalled(mockRedis.expire);
+                assert.calledWith(mockRedis.rpush,
+                    `${waitingJobsPrefix}${jobId}`, buildId);
+                assert.calledWith(mockWorker.queueObject.enqueueIn,
+                    DEFAULT_ENQUEUETIME * 1000 * 60, mockQueue, mockFunc, mockArgs);
+                assert.calledOnce(helperMock.updateBuildStatus);
+                assert.calledWith(helperMock.updateBuildStatus, {
                     buildId,
                     redisInstance: mockRedis,
                     status: 'BLOCKED',

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -140,7 +140,8 @@ describe('Jobs Unit Test', () => {
                     BlockedBy: {
                         reenqueueWaitTime: 1,
                         blockTimeout: 120,
-                        blockedBySelf: true
+                        blockedBySelf: true,
+                        collapse: true
                     }
                 },
                 perform: jobs.start.perform


### PR DESCRIPTION
- There is a race condition if build1 run really fast, build2 is waiting and build3 just come in.
- build3 will try collapse build2, but the moment it does it, build2 actually starts since we get the waiting list in the very beginning.
- add a check to see if `this.queueObject.connection.redis.lrem(waitingKey, 0, bId)` actually removes anything before collapse, if no, do not update status to `COLLAPSED`
- add a check to see `this.queueObject.connection.redis.lrem(waitingKey, 0, bId)` actually removes anything before starting the build, if no, do not start

In a nutshell, whoever gets to pop the build from the waiting queue will proceed.

tested in beta, this logic works fine, started 5 events with a delay of 5s: https://beta.cd.screwdriver.cd/pipelines/3189/events