### PR TITLE
fix(1482): fix race conditions for collapse

### DIFF
--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -36,13 +36,18 @@ async function collapseBuilds({ waitingKey, buildId, blockingBuildIds }) {
         winston.info('buildsToCollapse:', buildsToCollapse);
 
         const rmBuilds = buildsToCollapse.map(async (bId) => {
-            await this.queueObject.connection.redis.lrem(waitingKey, 0, bId);
-            await helper.updateBuildStatus({
-                redisInstance: this.queueObject.connection.redis,
-                buildId: bId,
-                status: 'COLLAPSED',
-                statusMessage: `Collapsed to build: ${buildId}`
-            }, () => {});
+            const count = await this.queueObject.connection.redis.lrem(waitingKey, 0, bId);
+
+            // if the build is no longer in the waiting queue, don't collapse it
+            if (count > 0) {
+                await helper.updateBuildStatus({
+                    redisInstance: this.queueObject.connection.redis,
+                    buildId: bId,
+                    status: 'COLLAPSED',
+                    statusMessage: `Collapsed to build: ${buildId}`
+                }, () => {});
+                await this.queueObject.connection.redis.hdel(`${queuePrefix}buildConfigs`, bId);
+            }
         });
 
         await Promise.all(rmBuilds);
@@ -59,7 +64,7 @@ async function collapseBuilds({ waitingKey, buildId, blockingBuildIds }) {
  * @param  {Number}      buildId        Current buildId
  * @return {Boolean}                    Whether this build is blocked
  */
-async function blockedBySelf({ waitingKey, buildId }) {
+async function blockedBySelf({ waitingKey, buildId, collapse }) {
     let waitingBuilds = await this.queueObject.connection.redis.lrange(waitingKey, 0, -1);
 
     // Only need to do this if there are waiting builds.
@@ -70,15 +75,21 @@ async function blockedBySelf({ waitingKey, buildId }) {
 
         // Get the first build that is waiting
         const firstWaitingBuild = waitingBuilds[0];
+        const lastWaitingBuild = waitingBuilds.slice(-1)[0];
+        const buildToStart = collapse ? lastWaitingBuild : firstWaitingBuild;
 
-        if (firstWaitingBuild !== buildId) {
-            await this.reEnqueue(waitingKey, buildId, firstWaitingBuild);
+        if (buildToStart !== buildId) {
+            await this.reEnqueue(waitingKey, buildId, buildToStart);
 
             return true; // blocked
         }
 
-        // If is the first waiting build, remove it and proceed
-        await this.queueObject.connection.redis.lrem(waitingKey, 0, firstWaitingBuild);
+        // If is the built to start, remove it and proceed
+        const count = await this.queueObject.connection.redis.lrem(
+            waitingKey, 0, buildToStart);
+
+        // Build has been removed from the waiting queue by other process, do not proceed
+        if (count < 1) return true;
 
         // Get the waiting jobs again - to prevent race condition where this value is changed in between
         const sameJobWaiting = await this.queueObject.connection.redis.llen(waitingKey);
@@ -112,21 +123,38 @@ class BlockedBy extends NodeResque.Plugin {
     async beforePerform() {
         const { jobId, buildId } = this.args[0];
         const runningKey = `${runningJobsPrefix}${jobId}`;
+        const lastRunningKey = `last_${runningJobsPrefix}${jobId}`;
         const waitingKey = `${waitingJobsPrefix}${jobId}`;
         const deleteKey = `deleted_${jobId}_${buildId}`;
         const enforceBlockedBySelf = String(this.options.blockedBySelf) === 'true'; // because kubernetes value is a string
         const shouldDelete = await this.queueObject.connection.redis.get(deleteKey);
         const runningBuildId = await this.queueObject.connection.redis.get(runningKey);
+        const lastRunningBuildId = await this.queueObject.connection.redis.get(lastRunningKey);
         const enableCollapse = String(this.options.collapse) === 'true'; // because kubernetes value is a string
         const buildConfig = await this.queueObject.connection.redis.hget(
             `${queuePrefix}buildConfigs`, buildId);
-        const collapse = hoek.reach(JSON.parse(buildConfig),
+        const collapseAnnotation = hoek.reach(JSON.parse(buildConfig),
             'annotations>screwdriver.cd/collapseBuilds', { default: true, separator: '>' });
+        const collapse = enableCollapse && collapseAnnotation;
 
         // For retry logic: failed to create pod, so it will retry
         // Current buildId is already set as runningKey. Should proceed
         if (parseInt(runningBuildId, 10) === buildId) {
             return true;
+        }
+
+        // Current build is older than last running build for the same job, discard the build
+        if (collapse && buildId < parseInt(lastRunningBuildId, 10)) {
+            await this.queueObject.connection.redis.lrem(waitingKey, 0, buildId);
+            await helper.updateBuildStatus({
+                redisInstance: this.queueObject.connection.redis,
+                buildId,
+                status: 'COLLAPSED',
+                statusMessage: `Collapsed to build: ${lastRunningBuildId}`
+            }, () => {});
+            await this.queueObject.connection.redis.hdel(`${queuePrefix}buildConfigs`, buildId);
+
+            return false;
         }
 
         // If this build is in the delete list (it was aborted)
@@ -167,7 +195,7 @@ class BlockedBy extends NodeResque.Plugin {
 
             // If any blocking job is running, then re-enqueue
             if (blockingBuildIds.length > 0) {
-                if (enforceBlockedBySelf && enableCollapse && collapse) {
+                if (enforceBlockedBySelf && collapse) {
                     await collapseBuilds.call(this, {
                         waitingKey,
                         buildId,
@@ -184,7 +212,8 @@ class BlockedBy extends NodeResque.Plugin {
             const blocked = await blockedBySelf.call(this, { // pass in this context
                 waitingKey,
                 buildId,
-                runningBuildId
+                runningBuildId,
+                collapse
             });
 
             if (blocked) { return false; } // if blocked then cannot proceed
@@ -194,10 +223,13 @@ class BlockedBy extends NodeResque.Plugin {
 
         // Register the curent job as running by setting key
         await this.queueObject.connection.redis.set(runningKey, buildId);
+        // Set lastRunningKey
+        await this.queueObject.connection.redis.set(lastRunningKey, buildId);
 
         // Set expire time to take care of the case where
         // afterPerform failed to call and blocked jobs will be stuck forever
         await this.queueObject.connection.redis.expire(runningKey, this.blockTimeout() * 60);
+        await this.queueObject.connection.redis.expire(lastRunningKey, this.blockTimeout() * 60);
 
         // Proceed
         return true;

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -120,7 +120,11 @@ class BlockedBy extends NodeResque.Plugin {
         const enableCollapse = String(this.options.collapse) === 'true'; // because kubernetes value is a string
         const buildConfig = await this.queueObject.connection.redis.hget(
             `${queuePrefix}buildConfigs`, buildId);
+<<<<<<< HEAD
         const collapse = hoek.reach(JSON.parse(buildConfig),
+=======
+        const collapse = hoek.reach(buildConfig,
+>>>>>>> feat: add collapse feature
             'annotations>screwdriver.cd/collapseBuilds', { default: true, separator: '>' });
 
         // For retry logic: failed to create pod, so it will retry

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -120,11 +120,7 @@ class BlockedBy extends NodeResque.Plugin {
         const enableCollapse = String(this.options.collapse) === 'true'; // because kubernetes value is a string
         const buildConfig = await this.queueObject.connection.redis.hget(
             `${queuePrefix}buildConfigs`, buildId);
-<<<<<<< HEAD
         const collapse = hoek.reach(JSON.parse(buildConfig),
-=======
-        const collapse = hoek.reach(buildConfig,
->>>>>>> feat: add collapse feature
             'annotations>screwdriver.cd/collapseBuilds', { default: true, separator: '>' });
 
         // For retry logic: failed to create pod, so it will retry

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -15,24 +15,29 @@ function updateBuildStatus(updateConfig, callback) {
 
     return redisInstance.hget(`${queuePrefix}buildConfigs`, buildId)
         .then(JSON.parse)
-        .then(fullBuildConfig => request({
-            json: true,
-            method: 'PUT',
-            uri: `${fullBuildConfig.apiUri}/v4/builds/${buildId}`,
-            body: {
-                status,
-                statusMessage
-            },
-            auth: {
-                bearer: fullBuildConfig.token
-            }
-        }, (err, response) => {
-            if (!err && response.statusCode === 200) {
-                return callback(null);
-            }
+        .then((fullBuildConfig) => {
+            // if fullBuildConfig got deleted already, do not update
+            if (!fullBuildConfig) return null;
 
-            return callback(err, response);
-        }));
+            return request({
+                json: true,
+                method: 'PUT',
+                uri: `${fullBuildConfig.apiUri}/v4/builds/${buildId}`,
+                body: {
+                    status,
+                    statusMessage
+                },
+                auth: {
+                    bearer: fullBuildConfig.token
+                }
+            }, (err, response) => {
+                if (!err && response.statusCode === 200) {
+                    return callback(null);
+                }
+
+                return callback(err, response);
+            });
+        });
 }
 
 module.exports = {

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -140,7 +140,8 @@ describe('Jobs Unit Test', () => {
                     BlockedBy: {
                         reenqueueWaitTime: 1,
                         blockTimeout: 120,
-                        blockedBySelf: true
+                        blockedBySelf: true,
+                        collapse: true
                     }
                 },
                 perform: jobs.start.perform


### PR DESCRIPTION
There are two major race conditions if multiple events start around the same time:
1. build0 finishes, build1 is in waiting queue and build2 comes around same time
-> build1 tries to start since it's the only one waiting
-> build2 tries to collapse build1 
this may leave build1 in a weird state, it's actually started but status is `COLLAPSE` and following builds will be blocked by it.
To solve this problem, add a check for `this.queueObject.connection.redis.lrem(waitingKey, 0, bId)`, whoever pops the build from the waitingQueue will proceed, otherwise return.

2. build1, build3 got picked up by worker first and build2 got picked up by worker later
-> build3 collapses build1 and starts after build0 finishes
-> build3 finishes, build2 will try to start since it's the only build waiting
To solve this, set `lastRunningKey ` when we set `runningKey`. And if a build is older that last running build, collapse and discard.

`Related to`: https://github.com/screwdriver-cd/screwdriver/issues/1482

