### PR TITLE
fix(1482): turn collapse feature flag into default behavior

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -178,7 +178,7 @@ plugins:
         blockTimeout: PLUGIN_BLOCKEDBY_BLOCK_TIMEOUT
         # job block by itself
         blockedBySelf: PLUGIN_BLOCKEDBY_BLOCKED_BY_SELF
-        # enable collapse feature or not
+        # by default collapse builds or not
         collapse: PLUGIN_BLOCKEDBY_COLLAPSE
 
 # Run queue-worker as a scheduler, instead of calling executor to start/stop builds, push it to rabbitmq

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -111,7 +111,7 @@ plugins:
       blockTimeout: 120
       # job blocked by itself
       blockedBySelf: true
-      # enable collapse feature or not
+      # by default collapse builds or not
       collapse: true
 
 # Run queue-worker as a scheduler, instead of calling executor to start/stop builds, push it to rabbitmq

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -133,9 +133,9 @@ class BlockedBy extends NodeResque.Plugin {
         const enableCollapse = String(this.options.collapse) === 'true'; // because kubernetes value is a string
         const buildConfig = await this.queueObject.connection.redis.hget(
             `${queuePrefix}buildConfigs`, buildId);
-        const collapseAnnotation = hoek.reach(JSON.parse(buildConfig),
-            'annotations>screwdriver.cd/collapseBuilds', { default: true, separator: '>' });
-        const collapse = enableCollapse && collapseAnnotation;
+        const collapse = hoek.reach(JSON.parse(buildConfig),
+            'annotations>screwdriver.cd/collapseBuilds',
+            { default: enableCollapse, separator: '>' });
 
         // For retry logic: failed to create pod, so it will retry
         // Current buildId is already set as runningKey. Should proceed

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-config-screwdriver": "^3.0.1",
     "jenkins-mocha": "^6.0.0",
     "mockery": "^2.1.0",
-    "sinon": "^7.2.3"
+    "sinon": "^7.2.4"
   },
   "dependencies": {
     "amqp-connection-manager": "^2.3.0",


### PR DESCRIPTION
- turn collapse feature flag into default behavior
- this way, cluster admin can decide if they want to opt in or opt out for `collapse` 

`Related to`: https://github.com/screwdriver-cd/screwdriver/issues/1482