### PR TITLE
fix: pull in new executor-k8s-vm with custom cpu and ram

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -79,12 +79,16 @@ executor:
                     low: K8S_CPU_LOW
                     high: K8S_CPU_HIGH
                     turbo: K8S_CPU_TURBO
+                    # upper bound for user custom cpu
+                    max: K8S_CPU_MAX
                 # Memory in GB
                 memory:
                     micro: K8S_MEMORY_MICRO
                     low: K8S_MEMORY_LOW
                     high: K8S_MEMORY_HIGH
                     turbo: K8S_MEMORY_TURBO
+                    # upper bound for user custom memory
+                    max: K8S_MEMORY_MAX
                 disk:
                   high: K8S_DISK_LABEL
                   speed: K8S_DISK_SPEED_LABEL

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -51,12 +51,16 @@ executor:
                     low: 2
                     high: 6
                     turbo: 12
+                    # upper bound for user custom cpu
+                    max: 12
                 memory:
                     # Memory in GB
                     micro: 1
                     low: 2
                     high: 12
                     turbo: 16
+                    # upper bound for user custom memory
+                    max: 16
             # Default build timeout for all builds in this cluster
             buildTimeout: 90
             # Default max build timeout

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-config-screwdriver": "^3.0.1",
     "jenkins-mocha": "^6.0.0",
     "mockery": "^2.1.0",
-    "sinon": "^7.2.4"
+    "sinon": "^7.2.5"
   },
   "dependencies": {
     "amqp-connection-manager": "^2.3.0",
@@ -53,7 +53,7 @@
     "screwdriver-executor-docker": "^3.2.0",
     "screwdriver-executor-jenkins": "^4.2.3",
     "screwdriver-executor-k8s": "^13.4.0",
-    "screwdriver-executor-k8s-vm": "^2.9.0",
+    "screwdriver-executor-k8s-vm": "^2.9.1",
     "screwdriver-executor-router": "^1.0.11",
     "winston": "^2.4.4"
   },


### PR DESCRIPTION
pull in new executor-k8s-vm with custom cpu and ram: https://github.com/screwdriver-cd/executor-k8s-vm/pull/55