### PR TITLE
fix: set block timeout based on build timeout

### DIFF
--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -5,6 +5,7 @@ const helper = require('./helper.js');
 const hoek = require('hoek');
 const { runningJobsPrefix, waitingJobsPrefix, queuePrefix } = require('../config/redis');
 const winston = require('winston');
+const BLOCK_TIMEOUT_BUFFER = 30;
 
 /**
  * collapse waiting builds and re-enequeue the current build if it is the latest one
@@ -133,9 +134,10 @@ class BlockedBy extends NodeResque.Plugin {
         const enableCollapse = String(this.options.collapse) === 'true'; // because kubernetes value is a string
         const buildConfig = await this.queueObject.connection.redis.hget(
             `${queuePrefix}buildConfigs`, buildId);
-        const collapse = hoek.reach(JSON.parse(buildConfig),
-            'annotations>screwdriver.cd/collapseBuilds',
-            { default: enableCollapse, separator: '>' });
+        const annotations = hoek.reach(JSON.parse(buildConfig), 'annotations', { default: {} });
+        const collapse = hoek.reach(annotations, 'screwdriver.cd/collapseBuilds', {
+            default: enableCollapse, separator: '>' });
+        const timeout = hoek.reach(annotations, 'screwdriver.cd/timeout', { separator: '>' });
 
         // For retry logic: failed to create pod, so it will retry
         // Current buildId is already set as runningKey. Should proceed
@@ -228,8 +230,10 @@ class BlockedBy extends NodeResque.Plugin {
 
         // Set expire time to take care of the case where
         // afterPerform failed to call and blocked jobs will be stuck forever
-        await this.queueObject.connection.redis.expire(runningKey, this.blockTimeout() * 60);
-        await this.queueObject.connection.redis.expire(lastRunningKey, this.blockTimeout() * 60);
+        await this.queueObject.connection.redis.expire(runningKey,
+            this.blockTimeout(timeout) * 60);
+        await this.queueObject.connection.redis.expire(lastRunningKey,
+            this.blockTimeout(timeout) * 60);
 
         // Proceed
         return true;
@@ -274,7 +278,11 @@ class BlockedBy extends NodeResque.Plugin {
         }, () => {});
     }
 
-    blockTimeout() { // same as build timeout
+    blockTimeout(buildTimeout) {
+        if (buildTimeout) {
+            return buildTimeout + BLOCK_TIMEOUT_BUFFER;
+        }
+
         if (this.options.blockTimeout) {
             return this.options.blockTimeout;
         }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-config-screwdriver": "^3.0.1",
     "jenkins-mocha": "^6.0.0",
     "mockery": "^2.1.0",
-    "sinon": "^7.2.5"
+    "sinon": "^7.2.7"
   },
   "dependencies": {
     "amqp-connection-manager": "^2.3.0",


### PR DESCRIPTION
We have a default block timeout of 2 hours to expire the running key to clean up things if the build doesn't end properly. But this will break builds that has a custom timeout of more than 2 hours. Key will be expired and next build will run even though the previous one is still running.

This PR will set block timeout based on build timeout with some buffer.