### PR TITLE
fix(1678): [1] add configurable retryDelay and maxAttempts

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -63,6 +63,10 @@ executor:
             breaker:
                 # in milliseconds
                 timeout: CIRCUIT_TIMEOUT
+        requestretry:
+            # in milliseconds
+            retryDelay: REQUEST_RETRYDELAY
+            maxAttempts: REQUEST_MAXATTEMPTS
     k8s-vm:
       options:
         # Configuration of Docker
@@ -122,6 +126,10 @@ executor:
             breaker:
                 # in milliseconds
                 timeout: CIRCUIT_TIMEOUT
+        requestretry:
+            # in milliseconds
+            retryDelay: REQUEST_RETRYDELAY
+            maxAttempts: REQUEST_MAXATTEMPTS
     jenkins:
       options:
         jenkins:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -38,6 +38,11 @@ executor:
             breaker:
                 # in milliseconds
                 timeout: 10000
+        # requestretry configs
+        requestretry:
+            # in milliseconds
+            retryDelay: 3000
+            maxAttempts: 5
     k8s-vm:
       options:
         # Configuration of Docker
@@ -78,6 +83,11 @@ executor:
             breaker:
                 # in milliseconds
                 timeout: 10000
+        # requestretry configs
+        requestretry:
+            # in milliseconds
+            retryDelay: 3000
+            maxAttempts: 5
 #     jenkins:
 #       options:
 #         # Configuration of Jenkins


### PR DESCRIPTION
## Context

[An error message](https://github.com/screwdriver-cd/executor-k8s/blob/2d52738caff561335b2aaa5c2620e4818b03c05b/index.js#L407-L409
) was not shown on UI and a build status was not changed even if users use invalid image.

This might be caused by pod's waiting reason is `PodInitializing` after [these retrying](https://github.com/screwdriver-cd/executor-k8s/blob/2d52738caff561335b2aaa5c2620e4818b03c05b/index.js#L391-L400).

## Objective
To prevent this problem, `MAXATTEMPTS` and `RETRYDELAY` should be configurable.
## References
https://github.com/screwdriver-cd/screwdriver/issues/1678

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
