### PR TITLE
fix: pull in latest executor-k8s-vm

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "screwdriver-executor-docker": "^3.2.0",
     "screwdriver-executor-jenkins": "^4.2.3",
     "screwdriver-executor-k8s": "^13.6.1",
-    "screwdriver-executor-k8s-vm": "^3.0.0",
+    "screwdriver-executor-k8s-vm": "^3.0.1",
     "screwdriver-executor-router": "^1.0.11",
     "winston": "^2.4.4"
   },


### PR DESCRIPTION
pull in latest executor-k8s-vm with preStop hook
https://github.com/screwdriver-cd/executor-k8s-vm/commit/e691cff956993cb12f6be4cc8e0d552a617291c6

## Reference
https://github.com/screwdriver-cd/screwdriver/issues/1676

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
