### PR TITLE
fix: Rename disk space config

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -96,7 +96,7 @@ executor:
                     # upper bound for user custom memory
                     max: K8S_MEMORY_MAX
                 disk:
-                  high: K8S_DISK_LABEL
+                  space: K8S_DISK_LABEL
                   speed: K8S_DISK_SPEED_LABEL
             # Default build timeout for all builds in this cluster
             buildTimeout: K8S_VM_BUILD_TIMEOUT


### PR DESCRIPTION
## Context

Make disk space config more generic. 

## Objective

This PR renames the disk space config from `high` to `space`.

## References

Related to https://github.com/screwdriver-cd/executor-k8s-vm/pull/60

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
