### PR TITLE
fix: fix runtime error when pipeline is gone

### DIFF
--- a/lib/Filter.js
+++ b/lib/Filter.js
@@ -26,6 +26,11 @@ class Filter extends NodeResque.Plugin {
         const buildConfig = await this.queueObject
             .connection.redis.hget(`${queuePrefix}buildConfigs`, buildId).then(JSON.parse);
 
+        if (!buildConfig) {
+            // this build or pipeline has already been deleted
+            return false;
+        }
+
         // if schedulerMode enabled, don't take anything without buildClusterName
         if (rabbitmqConf.getConfig().schedulerMode) {
             if (!buildConfig.buildClusterName) {

--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -94,6 +94,14 @@ describe('Plugin Test', () => {
                 assert.isTrue(proceed);
             });
 
+            it('doesn\'t proceed if build without buildConfig landed on worker', async () => {
+                mockRedis.hget.resolves(JSON.stringify(null));
+
+                const proceed = await filter.beforePerform();
+
+                assert.isFalse(proceed);
+            });
+
             it('re-enqueue if build with buildClusterName landed on worker', async () => {
                 buildConfig.buildClusterName = 'sd';
                 mockRedis.hget.resolves(JSON.stringify(buildConfig));
@@ -113,6 +121,16 @@ describe('Plugin Test', () => {
                 const proceed = await filter.beforePerform();
 
                 assert.isTrue(proceed);
+            });
+
+            it('doesn\'t proceed if build without buildConfig landed on scheduler', async () => {
+                mockRabbitmqConfigObj.schedulerMode = true;
+                mockRabbitmqConfig.getConfig.returns(mockRabbitmqConfigObj);
+                mockRedis.hget.resolves(JSON.stringify(null));
+
+                const proceed = await filter.beforePerform();
+
+                assert.isFalse(proceed);
             });
 
             it('re-enqueue if build without buildCluster landed on scheduler', async () => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
I found that there are thousands of failed "stop" job in my build queue (resque). It is caused by a TypeError on this line.
https://github.com/screwdriver-cd/queue-worker/blob/master/lib/Filter.js#L40
```
Cannot read property 'buildClusterName' of null
    at Filter.beforePerform (/usr/src/app/node_modules/screwdriver-queue-worker/lib/Filter.js:40:25)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
```

The root cause seems to get nonexistent buildConfig from redis after its pipeline is deleted.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
* Check if the existent of buildConfig and abort the processing if it is empty.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
