### PR TITLE
fix: Make worker option customizable

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -203,9 +203,9 @@ worker:
     minTaskProcessors: WORKER_MIN_TASK_PROCESSORS
     # maximum number of workers to spawn
     maxTaskProcessors: WORKER_MAX_TASK_PROCESSORS
-    # how often to check if the event loop is blocked
+    # how often to check if the event loop is blocked (ms)
     checkTimeout: WORKER_CHECK_TIMEOUT
-    # how long the event loop has to be delayed before considering it blocked
+    # how long the event loop has to be delayed before considering it blocked (ms)
     maxEventLoopDelay: WORKER_MAX_EVENT_LOOP_DELAY
 
 # Run queue-worker as a scheduler, instead of calling executor to start/stop builds, push it to rabbitmq

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -197,6 +197,17 @@ plugins:
         # by default collapse builds or not
         collapse: PLUGIN_BLOCKEDBY_COLLAPSE
 
+worker:
+    # https://github.com/taskrabbit/node-resque#multiworker-options
+    # minimum number of workers to spawn
+    minTaskProcessors: WORKER_MIN_TASK_PROCESSORS
+    # maximum number of workers to spawn
+    maxTaskProcessors: WORKER_MAX_TASK_PROCESSORS
+    # how often to check if the event loop is blocked
+    checkTimeout: WORKER_CHECK_TIMEOUT
+    # how long the event loop has to be delayed before considering it blocked
+    maxEventLoopDelay: WORKER_MAX_EVENT_LOOP_DELAY
+
 # Run queue-worker as a scheduler, instead of calling executor to start/stop builds, push it to rabbitmq
 scheduler:
     # Enabled schduler mode or not

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -137,9 +137,9 @@ worker:
     minTaskProcessors: 1
     # maximum number of workers to spawn
     maxTaskProcessors: 10
-    # how often to check if the event loop is blocked
+    # how often to check if the event loop is blocked (ms)
     checkTimeout: 1000
-    # how long the event loop has to be delayed before considering it blocked
+    # how long the event loop has to be delayed before considering it blocked (ms)
     maxEventLoopDelay: 10
 
 # Run queue-worker as a scheduler, instead of calling executor to start/stop builds, push it to rabbitmq

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -131,6 +131,17 @@ plugins:
       # by default collapse builds or not
       collapse: true
 
+worker:
+    # https://github.com/taskrabbit/node-resque#multiworker-options
+    # minimum number of workers to spawn
+    minTaskProcessors: 1
+    # maximum number of workers to spawn
+    maxTaskProcessors: 10
+    # how often to check if the event loop is blocked
+    checkTimeout: 1000
+    # how long the event loop has to be delayed before considering it blocked
+    maxEventLoopDelay: 10
+
 # Run queue-worker as a scheduler, instead of calling executor to start/stop builds, push it to rabbitmq
 scheduler:
     # Enabled schduler mode or not

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 'use strict';
 
 const NodeResque = require('node-resque');
+const config = require('config');
 const jobs = require('./lib/jobs');
 const helper = require('./lib/helper');
 const Redis = require('ioredis');
 const winston = require('winston');
+const workerConfig = config.get('worker');
 const { connectionDetails, queuePrefix } = require('./config/redis');
 const redis = new Redis(
     connectionDetails.port, connectionDetails.host, connectionDetails.options);
@@ -34,11 +36,10 @@ async function shutDownAll(worker, scheduler) {
 const multiWorker = new NodeResque.MultiWorker({
     connection: connectionDetails,
     queues: [`${queuePrefix}builds`],
-    minTaskProcessors: 1,
-    maxTaskProcessors: 10,
-    checkTimeout: 1000,
-    maxEventLoopDelay: 10,
-    toDisconnectProcessors: true
+    minTaskProcessors: workerConfig.minTaskProcessors,
+    maxTaskProcessors: workerConfig.maxTaskProcessors,
+    checkTimeout: workerConfig.checkTimeout,
+    maxEventLoopDelay: workerConfig.maxEventLoopDelay
 }, jobs);
 
 const scheduler = new NodeResque.Scheduler({ connection: connectionDetails });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
In my environment, many builds usually run at the same time.
Current worker watches pods until they are created, so this process fills up worker slots. And the number of workers is 10 (hardcoded).

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
I made MultiWorker option configurable so that users can scale their worker count via maxTaskProcessors.
Plus, I removed unused config `toDisconnectProcessors`.
https://github.com/taskrabbit/node-resque/commit/1e2be968813ff1f82234f37a4ce8ed97505b3e18

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
