### PR TITLE
fix: upgrade screwdriver-executor-docker to v4 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ioredis": "^3.2.2",
     "node-resque": "^5.5.3",
     "request": "^2.88.0",
-    "screwdriver-executor-docker": "^3.2.0",
+    "screwdriver-executor-docker": "^4.2.2",
     "screwdriver-executor-jenkins": "^4.2.3",
     "screwdriver-executor-k8s": "^13.6.1",
     "screwdriver-executor-k8s-vm": "^3.0.1",


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
`queue-worker` ought to be using the latest version of `screwdriver-executor-docker` v4 this case.

## Objective
This fix `queue-worker` to use `screwdriver-executor-docker` v4

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Screenshot:

![image](https://user-images.githubusercontent.com/15989893/68634716-3f87bb00-04ab-11ea-9ada-f28e6cbd1cc8.png)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
