### PR TITLE
fix: Prevent re-enqueue of builds from same event

### DIFF
--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -46,7 +46,7 @@ async function collapseBuilds({ waitingKey, buildId, blockingBuildIds }) {
                     buildId: bId,
                     status: 'COLLAPSED',
                     statusMessage: `Collapsed to build: ${buildId}`
-                }, () => {});
+                }, () => { });
                 await this.queueObject.connection.redis.hdel(`${queuePrefix}buildConfigs`, bId);
             }
         });
@@ -103,6 +103,41 @@ async function blockedBySelf({ waitingKey, buildId, collapse }) {
 
     return false;
 }
+
+/**
+ *
+ * @param {String} buildConfig
+ * @param {Array} blockingBuildIds
+ * @param {String} buildId
+ * @param {Object} redisConn
+ */
+async function checkMultipleBuildsFromSameEvent(buildConfig, blockingBuildIds, buildId, redisConn) {
+    if (!buildConfig) return false;
+
+    const parsedConfig1 = JSON.parse(buildConfig);
+
+    if (!parsedConfig1 || !parsedConfig1.eventId) {
+        return false;
+    }
+
+    const isSameEvent = await Promise.race(blockingBuildIds.map(async (b) => {
+        const bConfigs = await redisConn.hget(
+            `${queuePrefix}buildConfigs`, b
+        );
+        const parsedConfig2 = JSON.parse(bConfigs);
+        const hasEventId = parsedConfig2 && parsedConfig1.eventId;
+        const compare = hasEventId && (parsedConfig1.eventId === parsedConfig2.eventId);
+
+        if (compare) {
+            winston.info(`Builds ${b} & ${buildId} have the same event ${parsedConfig1.eventId}`);
+        }
+
+        return compare;
+    }));
+
+    return isSameEvent;
+}
+
 class BlockedBy extends NodeResque.Plugin {
     /**
    * Construct a new BlockedBy plugin
@@ -136,7 +171,8 @@ class BlockedBy extends NodeResque.Plugin {
             `${queuePrefix}buildConfigs`, buildId);
         const annotations = hoek.reach(JSON.parse(buildConfig), 'annotations', { default: {} });
         const collapse = hoek.reach(annotations, 'screwdriver.cd/collapseBuilds', {
-            default: enableCollapse, separator: '>' });
+            default: enableCollapse, separator: '>'
+        });
         const timeout = hoek.reach(annotations, 'screwdriver.cd/timeout', { separator: '>' });
 
         // For retry logic: failed to create pod, so it will retry
@@ -153,7 +189,7 @@ class BlockedBy extends NodeResque.Plugin {
                 buildId,
                 status: 'COLLAPSED',
                 statusMessage: `Collapsed to build: ${lastRunningBuildId}`
-            }, () => {});
+            }, () => { });
             await this.queueObject.connection.redis.hdel(`${queuePrefix}buildConfigs`, buildId);
 
             return false;
@@ -197,11 +233,24 @@ class BlockedBy extends NodeResque.Plugin {
 
             // If any blocking job is running, then re-enqueue
             if (blockingBuildIds.length > 0) {
-                if (enforceBlockedBySelf && collapse) {
+                // if build is from same event then don't re-enqueue
+                const isSameEvent = await checkMultipleBuildsFromSameEvent(
+                    buildConfig,
+                    blockingBuildIds,
+                    buildId,
+                    this.queueObject.connection.redis
+                );
+
+                if (isSameEvent) {
+                    winston.warn(`Multiple Builds ${buildId} triggered by the same event`);
+                    
+                    return false;
+                } else if (enforceBlockedBySelf && collapse) {
                     await collapseBuilds.call(this, {
                         waitingKey,
                         buildId,
-                        blockingBuildIds });
+                        blockingBuildIds
+                    });
                 } else {
                     await this.reEnqueue(waitingKey, buildId, blockingBuildIds);
                 }
@@ -279,7 +328,7 @@ class BlockedBy extends NodeResque.Plugin {
             buildId,
             status: 'BLOCKED',
             statusMessage
-        }, () => {});
+        }, () => { });
     }
 
     blockTimeout(buildTimeout) {

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -111,31 +111,32 @@ async function blockedBySelf({ waitingKey, buildId, collapse }) {
  * @param {String} buildId
  * @param {Object} redisConn
  */
-async function checkMultipleBuildsFromSameEvent(buildConfig, blockingBuildIds, buildId, redisConn) {
+async function checkMultipleBuildsInSameEvent(buildConfig, blockingBuildIds, buildId, redisConn) {
     if (!buildConfig) return false;
 
-    const parsedConfig1 = JSON.parse(buildConfig);
+    const currentBuild = JSON.parse(buildConfig);
 
-    if (!parsedConfig1 || !parsedConfig1.eventId) {
+    if (!currentBuild || !currentBuild.eventId || !currentBuild.jobId) {
         return false;
     }
 
-    const isSameEvent = await Promise.race(blockingBuildIds.map(async (b) => {
-        const bConfigs = await redisConn.hget(
-            `${queuePrefix}buildConfigs`, b
-        );
-        const parsedConfig2 = JSON.parse(bConfigs);
-        const hasEventId = parsedConfig2 && parsedConfig1.eventId;
-        const compare = hasEventId && (parsedConfig1.eventId === parsedConfig2.eventId);
+    const isSameBuild = await Promise.race(blockingBuildIds.map(async (id) => {
+        const blockedBuild = JSON.parse(await redisConn.hget(
+            `${queuePrefix}buildConfigs`, id
+        ));
+        const hasEventId = blockedBuild && blockedBuild.eventId && blockedBuild.jobId;
+        const isSameJob = hasEventId && (currentBuild.eventId === blockedBuild.eventId)
+            && (currentBuild.jobId === blockedBuild.jobId);
 
-        if (compare) {
-            logger.info(`Builds ${b} & ${buildId} have the same event ${parsedConfig1.eventId}`);
+        if (isSameJob) {
+            logger.error(`Builds ${id} & ${buildId} have the same event 
+                ${currentBuild.eventId} & same job ${currentBuild.jobId}`);
         }
 
-        return compare;
+        return isSameJob;
     }));
 
-    return isSameEvent;
+    return isSameBuild;
 }
 
 class BlockedBy extends NodeResque.Plugin {
@@ -234,16 +235,14 @@ class BlockedBy extends NodeResque.Plugin {
             // If any blocking job is running, then re-enqueue
             if (blockingBuildIds.length > 0) {
                 // if build is from same event then don't re-enqueue
-                const isSameEvent = await checkMultipleBuildsFromSameEvent(
+                const isSameBuild = await checkMultipleBuildsInSameEvent(
                     buildConfig,
                     blockingBuildIds,
                     buildId,
                     this.queueObject.connection.redis
                 );
 
-                if (isSameEvent) {
-                    logger.warn(`Multiple Builds ${buildId} triggered by the same event`);
-
+                if (isSameBuild) {
                     return false;
                 } else if (enforceBlockedBySelf && collapse) {
                     await collapseBuilds.call(this, {

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -129,7 +129,7 @@ async function checkMultipleBuildsFromSameEvent(buildConfig, blockingBuildIds, b
         const compare = hasEventId && (parsedConfig1.eventId === parsedConfig2.eventId);
 
         if (compare) {
-            winston.info(`Builds ${b} & ${buildId} have the same event ${parsedConfig1.eventId}`);
+            logger.info(`Builds ${b} & ${buildId} have the same event ${parsedConfig1.eventId}`);
         }
 
         return compare;
@@ -242,7 +242,7 @@ class BlockedBy extends NodeResque.Plugin {
                 );
 
                 if (isSameEvent) {
-                    winston.warn(`Multiple Builds ${buildId} triggered by the same event`);
+                    logger.warn(`Multiple Builds ${buildId} triggered by the same event`);
 
                     return false;
                 } else if (enforceBlockedBySelf && collapse) {

--- a/lib/BlockedBy.js
+++ b/lib/BlockedBy.js
@@ -243,7 +243,7 @@ class BlockedBy extends NodeResque.Plugin {
 
                 if (isSameEvent) {
                     winston.warn(`Multiple Builds ${buildId} triggered by the same event`);
-                    
+
                     return false;
                 } else if (enforceBlockedBySelf && collapse) {
                     await collapseBuilds.call(this, {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ioredis": "^3.2.2",
     "node-resque": "^5.5.3",
     "request": "^2.88.0",
-    "screwdriver-executor-docker": "^3.2.0",
+    "screwdriver-executor-docker": "^4.2.2",
     "screwdriver-executor-jenkins": "^4.2.3",
     "screwdriver-executor-k8s": "^13.6.1",
     "screwdriver-executor-k8s-vm": "^3.0.1",

--- a/test/blockedBy.test.js
+++ b/test/blockedBy.test.js
@@ -407,7 +407,8 @@ describe('Plugin Test', () => {
                         'screwdriver.cd/timeout': 200,
                         'screwdriver.cd/collapseBuilds': false
                     },
-                    eventId: '345'
+                    eventId: '345',
+                    jobId: '777'
                 };
 
                 const buildConfig2 = {
@@ -417,7 +418,8 @@ describe('Plugin Test', () => {
                         'screwdriver.cd/timeout': 300,
                         'screwdriver.cd/collapseBuilds': false
                     },
-                    eventId: '345'
+                    eventId: '345',
+                    jobId: '777'
                 };
 
                 const buildConfig3 = {
@@ -427,7 +429,8 @@ describe('Plugin Test', () => {
                         'screwdriver.cd/timeout': 500,
                         'screwdriver.cd/collapseBuilds': false
                     },
-                    eventId: '344'
+                    eventId: '344',
+                    jobId: '111'
                 };
 
                 mockRedis.hget.withArgs(`${queuePrefix}buildConfigs`, buildId)
@@ -541,7 +544,7 @@ describe('Plugin Test', () => {
                 });
             });
 
-            it('do not re-enqueu if current build is older than waiting builds', async () => {
+            it('do not re-enqueue if current build is older than waiting builds', async () => {
                 blockedBy = new BlockedBy(mockWorker, mockFunc, mockQueue, mockJob, mockArgs, {
                     blockedBySelf: true,
                     collapse: true

--- a/test/blockedBy.test.js
+++ b/test/blockedBy.test.js
@@ -14,10 +14,11 @@ describe('Plugin Test', () => {
     const buildId = 3;
     const buildIdStr = '3';
     const mockJob = {};
-    const mockFunc = () => {};
+    const mockFunc = () => { };
     const mockQueue = 'queuename';
     const runningJobsPrefix = 'mockRunningJobsPrefix_';
     const waitingJobsPrefix = 'mockRunningJobsPrefix_';
+    const queuePrefix = undefined;
     const deleteKey = `deleted_${jobId}_${buildId}`;
     const runningKey = `${runningJobsPrefix}777`;
     const key = `${runningJobsPrefix}${jobId}`;
@@ -80,7 +81,8 @@ describe('Plugin Test', () => {
         BlockedBy = require('../lib/BlockedBy.js').BlockedBy;
 
         blockedBy = new BlockedBy(mockWorker, mockFunc, mockQueue, mockJob, mockArgs, {
-            blockedBySelf: true });
+            blockedBySelf: true
+        });
     });
 
     afterEach(() => {
@@ -223,7 +225,7 @@ describe('Plugin Test', () => {
                     redisInstance: mockRedis,
                     status: 'BLOCKED',
                     statusMessage: 'Blocked by these running build(s): ' +
-                    '<a href="/builds/123">123</a>'
+                        '<a href="/builds/123">123</a>'
                 });
             });
 
@@ -250,7 +252,7 @@ describe('Plugin Test', () => {
                     redisInstance: mockRedis,
                     status: 'BLOCKED',
                     statusMessage: 'Blocked by these running build(s): ' +
-                    '<a href="/builds/123">123</a>, <a href="/builds/456">456</a>'
+                        '<a href="/builds/123">123</a>, <a href="/builds/456">456</a>'
                 });
             });
 
@@ -292,7 +294,7 @@ describe('Plugin Test', () => {
                     redisInstance: mockRedis,
                     status: 'BLOCKED',
                     statusMessage: 'Blocked by these running build(s): ' +
-                    '<a href="/builds/123">123</a>'
+                        '<a href="/builds/123">123</a>'
                 });
             });
 
@@ -323,7 +325,7 @@ describe('Plugin Test', () => {
                     redisInstance: mockRedis,
                     status: 'BLOCKED',
                     statusMessage: 'Blocked by these running build(s): ' +
-                    '<a href="/builds/123">123</a>'
+                        '<a href="/builds/123">123</a>'
                 });
             });
 
@@ -354,7 +356,7 @@ describe('Plugin Test', () => {
                     redisInstance: mockRedis,
                     status: 'BLOCKED',
                     statusMessage: 'Blocked by these running build(s): ' +
-                    '<a href="/builds/123">123</a>'
+                        '<a href="/builds/123">123</a>'
                 });
             });
 
@@ -384,8 +386,69 @@ describe('Plugin Test', () => {
                     redisInstance: mockRedis,
                     status: 'BLOCKED',
                     statusMessage: 'Blocked by these running build(s): ' +
-                    '<a href="/builds/123">123</a>'
+                        '<a href="/builds/123">123</a>'
                 });
+            });
+
+            it('do not re-enqueue if build from the same event id', async () => {
+                mockArgs = [{
+                    jobId,
+                    buildId,
+                    blockedBy: '3,4,5'
+                }];
+                blockedBy = new BlockedBy(mockWorker, mockFunc, mockQueue, mockJob, mockArgs, {
+                    blockedBySelf: true,
+                    collapse: true
+                });
+                const buildConfig1 = {
+                    apiUri: 'foo.bar',
+                    token: 'fake',
+                    annotations: {
+                        'screwdriver.cd/timeout': 200,
+                        'screwdriver.cd/collapseBuilds': false
+                    },
+                    eventId: '345'
+                };
+
+                const buildConfig2 = {
+                    apiUri: 'foo.foo',
+                    token: 'morefake',
+                    annotations: {
+                        'screwdriver.cd/timeout': 300,
+                        'screwdriver.cd/collapseBuilds': false
+                    },
+                    eventId: '345'
+                };
+
+                const buildConfig3 = {
+                    apiUri: 'bar.foo',
+                    token: 'stillfake',
+                    annotations: {
+                        'screwdriver.cd/timeout': 500,
+                        'screwdriver.cd/collapseBuilds': false
+                    },
+                    eventId: '344'
+                };
+
+                mockRedis.hget.withArgs(`${queuePrefix}buildConfigs`, buildId)
+                    .resolves(JSON.stringify(buildConfig1));
+                mockRedis.hget.withArgs(`${queuePrefix}buildConfigs`, '4')
+                    .resolves(JSON.stringify(buildConfig2));
+                mockRedis.hget.withArgs(`${queuePrefix}buildConfigs`, '5')
+                    .resolves(JSON.stringify(buildConfig3));
+                mockRedis.get.withArgs(`${runningJobsPrefix}3`).resolves('4');
+                mockRedis.lrange.resolves(['3']);
+                helperMock.updateBuildStatus.yieldsAsync(null, {});
+                await blockedBy.beforePerform();
+                assert.equal(mockRedis.get.getCall(0).args[0], deleteKey);
+                assert.equal(mockRedis.get.getCall(1).args[0], runningKey);
+                assert.equal(mockRedis.get.getCall(2).args[0], `last_${runningKey}`);
+                assert.equal(mockRedis.get.getCall(3).args[0], `${runningJobsPrefix}3`);
+                assert.equal(mockRedis.get.getCall(4).args[0], `${runningJobsPrefix}4`);
+                assert.notCalled(mockRedis.set);
+                assert.notCalled(mockRedis.expire);
+                assert.notCalled(mockRedis.lrem);
+                assert.notCalled(mockWorker.queueObject.enqueueIn);
             });
 
             it('do not collapse if waiting build is the latest one', async () => {
@@ -412,7 +475,7 @@ describe('Plugin Test', () => {
                     redisInstance: mockRedis,
                     status: 'BLOCKED',
                     statusMessage: 'Blocked by these running build(s): ' +
-                    '<a href="/builds/123">123</a>'
+                        '<a href="/builds/123">123</a>'
                 });
             });
 
@@ -474,7 +537,7 @@ describe('Plugin Test', () => {
                     redisInstance: mockRedis,
                     status: 'BLOCKED',
                     statusMessage: 'Blocked by these running build(s): ' +
-                    '<a href="/builds/123">123</a>'
+                        '<a href="/builds/123">123</a>'
                 });
             });
 
@@ -556,7 +619,7 @@ describe('Plugin Test', () => {
                         redisInstance: mockRedis,
                         status: 'BLOCKED',
                         statusMessage: 'Blocked by these running build(s): ' +
-                        '<a href="/builds/2">2</a>'// blocked by itself
+                            '<a href="/builds/2">2</a>'// blocked by itself
                     });
                 });
 


### PR DESCRIPTION
## Context

Due to api slowness and retry logic sometimes multiple builds from the same event gets triggered irrespective of the build status. This causes downline jobs to get triggered multiple times.

## Objective

This PR will add a check to prevent builds triggered from the same eventId to not be re-enqueued

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
