### PR TITLE
fix(1830): add cache2disk md5, compress, maxsize env var

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -173,6 +173,13 @@ ecosystem:
     store: ECOSYSTEM_STORE
     # Pushgateway URL for Prometheus
     pushgatewayUrl: ECOSYSTEM_PUSHGATEWAY_URL
+    # build cache strategies: s3, disk, with s3 as default option to store cache
+    cache:
+        strategy: CACHE_STRATEGY
+        path: CACHE_PATH
+        compress: CACHE_COMPRESS
+        md5check: CACHE_MD5CHECK
+        max_size_mb: CACHE_MAX_SIZE_MB
 
 redis:
     # Host of redis cluster

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -108,6 +108,13 @@ ecosystem:
     api: https://api.screwdriver.cd
     # Externally routable URL for the Artifact Store
     store: https://store.screwdriver.cd
+    # build cache strategies: s3, disk, with s3 as default option to store cache
+    cache:
+        strategy: "s3"
+        path: "/"
+        compress: false
+        md5check: false
+        max_size_mb: 0
 
 redis:
     # Host of redis cluster

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "screwdriver-executor-docker": "^4.2.2",
     "screwdriver-executor-jenkins": "^4.2.3",
     "screwdriver-executor-k8s": "^13.6.1",
-    "screwdriver-executor-k8s-vm": "^3.1.1",
+    "screwdriver-executor-k8s-vm": "^3.1.3",
     "screwdriver-executor-router": "^1.0.11",
     "screwdriver-logger": "^1.0.0"
   },


### PR DESCRIPTION
## Objective

add md5 check, compress, max limit environment variables for local cache

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
