### PR TITLE
fix(1839): Add timeout check to worker

### DIFF
--- a/lib/timeout.js
+++ b/lib/timeout.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const helper = require('./helper.js');
+const hoek = require('hoek');
+const { waitingJobsPrefix, runningJobsPrefix, queuePrefix } = require('../config/redis');
+const logger = require('screwdriver-logger');
+const DEFAULT_BUILD_TIMEOUT = 60;
+
+/**
+ * Check if the build has timed out
+ * If yes, abort build.
+ * @method check
+ * @return {Promise}
+ */
+async function check(redis) {
+    try {
+        const keys = await redis.hkeys(`${queuePrefix}buildConfigs`);
+
+        if (!keys || keys.length === 0) return;
+
+        await Promise.all(keys.map(async (buildId) => {
+            const json = await redis.hget(
+                `${queuePrefix}buildConfigs`, buildId);
+
+            if (!json) return;
+
+            const buildConfig = JSON.parse(json);
+            const jobId = buildConfig.jobId;
+            const runningKey = `${runningJobsPrefix}${jobId}`;
+            const lastRunningKey = `last_${runningJobsPrefix}${jobId}`;
+            const waitingKey = `${waitingJobsPrefix}${jobId}`;
+            const deleteKey = `deleted_${jobId}_${buildId}`;
+
+            if (!buildConfig) {
+                // this build or pipeline has already been deleted
+                return;
+            }
+
+            const annotations = hoek.reach(buildConfig, 'annotations', { default: {} });
+            const timeout = parseInt(annotations.timeout || DEFAULT_BUILD_TIMEOUT, 10);
+            const startTime = buildConfig.enqueueTime;
+
+            if (!startTime) {
+                // there is no enqueue time set for the build
+                logger.warn(`EnqueueTime not set for buildId: ${buildId}`);
+
+                return;
+            }
+
+            const diffMs = (new Date()).getTime() - new Date(startTime).getTime();
+            const diffMins = Math.round(diffMs / 60000);
+
+            // check if build has timed out, if yes abort build
+            if (diffMins > timeout) {
+                logger.info(`Build has timed out ${buildId}`);
+
+                await helper.updateBuildStatus({
+                    redisInstance: redis,
+                    buildId,
+                    status: 'FAILURE', // 'ABORTED'
+                    statusMessage: `Failed build: ${buildId} due to timeout`
+                }, () => { });
+
+                await redis.hdel(`${queuePrefix}buildConfigs`, buildId);
+
+                // expire now as build aborted
+                await redis.expire(runningKey, 0);
+                await redis.expire(lastRunningKey, 0);
+
+                await redis.del(deleteKey);
+                await redis.lrem(waitingKey, 0, buildId);
+            }
+        }));
+    } catch (err) {
+        logger.error(`Error occured while checking timeout ${err}`);
+    }
+}
+
+module.exports.check = check;

--- a/test/timeout.test.js
+++ b/test/timeout.test.js
@@ -1,0 +1,171 @@
+'use strict';
+
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+let deleteKey;
+let expireKey;
+let waitingKey;
+
+describe('Timeout test', () => {
+    const queuePrefix = 'mockQueuePrefix_';
+    const runningJobsPrefix = undefined;
+    const waitingJobsPrefix = undefined;
+    let mockRequest;
+    let mockRedis;
+    let mockRedisConfig;
+    let helperMock;
+    let timeout;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        mockRequest = sinon.stub();
+        mockRedis = {
+            hget: sinon.stub().resolves(),
+            hdel: sinon.stub().resolves(null),
+            get: sinon.stub().resolves(null),
+            expire: sinon.stub().resolves(),
+            del: sinon.stub().resolves(),
+            lrem: sinon.stub().resolves(),
+            hkeys: sinon.stub().resolves()
+        };
+
+        mockRedisConfig = {
+            queuePrefix: 'mockQueuePrefix_'
+        };
+        helperMock = {
+            updateBuildStatus: sinon.stub()
+        };
+
+        mockery.registerMock('request', mockRequest);
+        mockery.registerMock('../config/redis', mockRedisConfig);
+        mockery.registerMock('./helper.js', helperMock);
+
+        // eslint-disable-next-line global-require
+        timeout = require('../lib/timeout.js');
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.resetCache();
+        process.removeAllListeners('SIGTERM');
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    describe('check', () => {
+        beforeEach(() => {
+            expireKey = `${runningJobsPrefix}2`;
+            waitingKey = `${waitingJobsPrefix}2`;
+
+            mockRedis.hkeys.withArgs(`${queuePrefix}buildConfigs`)
+                .resolves(['222', '333', '444']);
+        });
+
+        it('Updates build status to FAILURE if time difference is greater than timeout'
+            , async () => {
+                const now = new Date();
+
+                now.setHours(now.getHours() - 1);
+
+                // helperMock.updateBuildStatus.yieldsAsync(null, {});
+
+                const buildId = '333';
+                const buildConfig = {
+                    jobId: 2,
+                    jobName: 'deploy',
+                    annotations: {
+                        timeout: '50'
+                    },
+                    apiUri: 'fake',
+                    buildId,
+                    eventId: 75,
+                    enqueueTime: now
+                };
+
+                deleteKey = `deleted_${buildConfig.jobId}_${buildId}`;
+
+                mockRedis.hget.withArgs(`${queuePrefix}buildConfigs`, buildId)
+                    .resolves(JSON.stringify(buildConfig));
+
+                await timeout.check(mockRedis);
+
+                assert.calledWith(helperMock.updateBuildStatus, {
+                    redisInstance: mockRedis,
+                    buildId,
+                    status: 'FAILURE',
+                    statusMessage: `Failed build: ${buildId} due to timeout`
+                });
+                assert.calledWith(mockRedis.hdel, `${queuePrefix}buildConfigs`, buildId);
+                assert.calledWith(mockRedis.expire, expireKey, 0);
+                assert.calledWith(mockRedis.expire, expireKey, 0);
+
+                assert.calledWith(mockRedis.del, deleteKey);
+                assert.calledWith(mockRedis.lrem, waitingKey, 0, buildId);
+            });
+
+        it('Updatebuildstatus not called if time difference still less than timeout', async () => {
+            const now = new Date();
+
+            now.setMinutes(now.getMinutes() - 20);
+
+            const buildId = '333';
+            const buildConfig = {
+                jobId: 2,
+                jobName: 'deploy',
+                annotations: {
+                    timeout: '50'
+                },
+                apiUri: 'fake',
+                buildId,
+                eventId: 76,
+                enqueueTime: now
+            };
+
+            mockRedis.hget.withArgs(`${queuePrefix}buildConfigs`, buildId)
+                .resolves(JSON.stringify(buildConfig));
+
+            await timeout.check(mockRedis);
+
+            assert.notCalled(helperMock.updateBuildStatus);
+            assert.notCalled(mockRedis.expire);
+            assert.notCalled(mockRedis.del);
+            assert.notCalled(mockRedis.lrem);
+        });
+
+        it('No op if enqueue time is not set in build config', async () => {
+            const buildId = '222';
+            const buildConfig = {
+                jobId: 2,
+                jobName: 'deploy',
+                annotations: {
+                    timeout: '50'
+                },
+                apiUri: 'fake',
+                buildId,
+                eventId: 76
+            };
+
+            mockRedis.hget.withArgs(`${queuePrefix}buildConfigs`, buildId)
+                .resolves(JSON.stringify(buildConfig));
+
+            await timeout.check(mockRedis);
+
+            assert.notCalled(helperMock.updateBuildStatus);
+            assert.notCalled(mockRedis.expire);
+            assert.notCalled(mockRedis.del);
+            assert.notCalled(mockRedis.lrem);
+        });
+    });
+});


### PR DESCRIPTION
## Context

Build time out which is enforced via launcher doesn't work on scenarios when build container crashes. This is because it relies on launcher process to be running to enforce the time out.

## Objective

This PR checks whether the time build has spent being processed is greater than the timeout of the build and updates the status to FAILURE. This fixes the case when container has crashed but the build shows still running with no way stop without manual intervention.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1839

Other related PR's, add property to schema and buildConfig
https://github.com/screwdriver-cd/data-schema/pull/371
https://github.com/screwdriver-cd/executor-queue/pull/77

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
