### PR TITLE
fix: pull in new executor-jenkins

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "node-resque": "^5.5.3",
     "request": "^2.88.0",
     "screwdriver-executor-docker": "^4.2.2",
-    "screwdriver-executor-jenkins": "^4.2.3",
+    "screwdriver-executor-jenkins": "^4.5.0",
     "screwdriver-executor-k8s": "^13.6.1",
     "screwdriver-executor-k8s-vm": "^3.2.2",
     "screwdriver-executor-router": "^1.0.11",


### PR DESCRIPTION
## Context, Objective
pull in new executor-jenkins to queue-worker

## References
https://github.com/screwdriver-cd/executor-jenkins/releases/tag/v4.5.0
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
