### PR TITLE
fix: refactor log

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -32,7 +32,7 @@ function updateBuildStatus(updateConfig, callback) {
                 }
             }, (err, response) => {
                 if (!err && response.statusCode === 200) {
-                    return callback(null);
+                    return callback(null, response);
                 }
 
                 return callback(err, response);

--- a/lib/timeout.js
+++ b/lib/timeout.js
@@ -63,7 +63,7 @@ async function process(timeoutConfig, buildId, redis) {
                 statusMessage: 'Build failed due to timeout'
             }, (err, response) => {
                 // successfly update a build status to FAILURE
-                if (!err && response.statusCode === 200) {
+                if (!err && response && response.statusCode === 200) {
                     logger.info(`Build has timed out ${buildId}`);
                 }
             });

--- a/lib/timeout.js
+++ b/lib/timeout.js
@@ -36,8 +36,6 @@ async function process(timeoutConfig, buildId, redis) {
 
         // check if build has timed out, if yes abort build
         if (diffMins > timeout) {
-            logger.info(`Build has timed out ${buildId}`);
-
             let step;
 
             try {
@@ -46,7 +44,7 @@ async function process(timeoutConfig, buildId, redis) {
                     buildId
                 });
             } catch (err) {
-                logger.error(`No active step found for  ${buildId}`);
+                logger.error(`No active step found for ${buildId}`);
             }
 
             if (step) {
@@ -63,7 +61,12 @@ async function process(timeoutConfig, buildId, redis) {
                 buildId,
                 status: 'FAILURE',
                 statusMessage: 'Build failed due to timeout'
-            }, () => { });
+            }, (err, response) => {
+                // successfly update a build status to FAILURE
+                if (!err && response.statusCode === 200) {
+                    logger.info(`Build has timed out ${buildId}`);
+                }
+            });
 
             await redis.hdel(`${queuePrefix}buildConfigs`, buildId);
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:


### PR DESCRIPTION
## Context
`Build has timed out` logs are spamming and annoying even if the builds have been finished.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Logs will be appeared after `updateBuildStatus`.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
